### PR TITLE
BibAuthorID: Fix APPP title name display

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_name_utils.py
+++ b/modules/bibauthorid/lib/bibauthorid_name_utils.py
@@ -964,16 +964,18 @@ def most_relevant_name(name_variants):
     '''
     if not name_variants:
         return None
-    name_parts_list = []
+    name_parts_list = list()
 
     for name in name_variants:
-        name_parts_list.append(create_normalized_name(split_name_parts(name)))
-    sorted_by_relevance_name_list = sorted(
-        sorted(name_parts_list,
-               key=lambda k: len(k[1]),
-               reverse=True),
-        key=lambda k: len(k[2]),
-        reverse=True)
+        name_parts_list.append(split_name_parts(name))
+
+    sorted_by_initials = sorted(name_parts_list,
+                                key=lambda k: len(k[1]),
+                                reverse=True)
+
+    sorted_by_relevance_name_list = sorted(sorted_by_initials,
+                                           key=lambda k: len(k[2]),
+                                           reverse=True)
 
     return sorted_by_relevance_name_list[0]
 

--- a/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py
@@ -394,8 +394,9 @@ def _get_external_publications(person_id):
 
         arxiv_pubs = dict()
         for arxiv_pubid in arxiv_pub_ids:
-            recids = perform_request_search(p=arxiv_pubid, f='037', m1='e', cc='HEP', rg=0)
-            if not recids:
+            recids_hep = perform_request_search(p=arxiv_pubid, cc='HEP', rg=0)
+            recids_data = perform_request_search(p=arxiv_pubid, cc='Data', rg=0)
+            if not (recids_hep or recids_data):
                 arxiv_pubs[arxiv_pubid] = get_title_of_arxiv_pubid(arxiv_pubid)
 
             if IS_BATCH_PROCESS:
@@ -417,8 +418,9 @@ def _get_external_publications(person_id):
 
         orcid_pubs = dict()
         for doi in orcid_dois:
-            recids = perform_request_search(p=doi, f='doi', m1='e', cc='HEP', rg=0)
-            if not recids:
+            recids_hep = perform_request_search(p=doi, cc='HEP', rg=0)
+            recids_data = perform_request_search(p=doi, cc='Data', rg=0)
+            if not (recids_hep or recids_data):
                 orcid_pubs[doi] = get_title_of_doi(doi)
 
             if IS_BATCH_PROCESS:


### PR DESCRIPTION
- The selection of the most relevant name to be
  used as a title for the APPP does not crash
  anymore when handling empty names.

Signed-off-by: Samuele Carli samuele.carli@cern.ch
Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
