### PR TITLE
Add user mail logs to cataloger submissions

### DIFF
--- a/modules/bibedit/lib/bibedit_utils.py
+++ b/modules/bibedit/lib/bibedit_utils.py
@@ -379,10 +379,13 @@ def save_xml_record(recid, uid, xml_record='', to_upload=True, to_merge=False,
     if to_upload:
         args = ['bibupload', user_name, '-P', '5', '-r',
                 file_path, '-u', user_name]
+        user_email = get_email(uid) or None
+        if user_email:
+            args.extend(['--email-logs-to', user_email])
         if task_name == "bibedit":
-            args += ['--name', 'bibedit']
+            args.extend(['--name', 'bibedit'])
         if sequence_id:
-            args += ["-I", sequence_id]
+            args.extend(["-I", sequence_id])
         task_low_level_submission(*args)
     return True
 

--- a/modules/bibedit/lib/bibeditmulti_engine.py
+++ b/modules/bibedit/lib/bibeditmulti_engine.py
@@ -393,7 +393,7 @@ def perform_request_detailed_record(record_id, update_commands, output_format, l
     response['search_html'] = multiedit_templates.detailed_record(record_content, language)
     return response
 
-def perform_request_test_search(search_criteria, update_commands, output_format, page_to_display, 
+def perform_request_test_search(search_criteria, update_commands, output_format, page_to_display,
                                 language, outputTags, collection="", compute_modifications=0,
                                 upload_mode='-c', req=None, checked_records=None):
     """Returns the results of a test search.
@@ -681,7 +681,11 @@ def _upload_file_with_bibupload(file_path, upload_mode, num_records, req):
     """
     user_info = collect_user_info(req)
     user_name = user_info.get('nickname') or 'multiedit'
+    user_email = user_info.get('email') or None
     task_options = ['bibupload', user_name, '-N', 'multiedit', '-P', '4', upload_mode]
+
+    if user_email:
+        task_options.extend(["--email-logs-to", user_email])
 
     if num_records < CFG_BIBEDITMULTI_LIMIT_INSTANT_PROCESSING:
         task_options.append('%s' % file_path)


### PR DESCRIPTION
Our cataloguers cannot currently see the error output of any update submitted through BibEdit or Multi-edit. This pull requests aims to give them this information to more quickly respond to failures.

Granted, it may provide some spam for the users as well as it will also send e-mails upon completed submissions, and this could perhaps be solved at the BibUpload level to send to the offending user who created the task upon error?

What do you think?

@Osso @kaplun @jmartinm @fschwenn
