### PR TITLE
Websearch: SPIRES to Invenio keyword translation

### DIFF
--- a/modules/miscutil/lib/upgrades/invenio_2014_06_06_new_field_note.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_06_06_new_field_note.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2012, 2013 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "New note field."
+
+
+def do_upgrade():
+    pass
+
+
+def do_upgrade_atlantis():
+    field_id = run_sql("""INSERT INTO field SET name='note', code='note'""")
+    tag_id = run_sql("""INSERT INTO tag SET name='note', value='500__a'""")
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 10)""",
+        (field_id, tag_id)
+    )
+
+
+def estimate():
+    return 1
+
+
+def pre_upgrade():
+    pass
+
+
+def post_upgrade():
+    pass

--- a/modules/miscutil/lib/upgrades/invenio_2014_06_10_new_field_address.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_06_10_new_field_address.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from logging import warn
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "New address field."
+
+
+def do_upgrade():
+    pass
+
+
+def do_upgrade_atlantis():
+    field_id = run_sql(
+        """INSERT INTO field SET name='address', code='address')"""
+    )
+    tag_371x_id = run_sql(
+        """INSERT INTO tag SET name='address', value='371__%%')"""
+    )
+    tag_110x_id = run_sql(
+        """INSERT INTO tag SET name='110__(any)', value='110__%%')"""
+    )
+    tag_410g_id = run_sql(
+        """INSERT INTO tag SET name='410__g', value='410__g')"""
+    )
+
+    query_410a_id = run_sql(
+        """SELECT id FROM tag WHERE value='410__a')"""
+    )
+    if query_410a_id:
+        tag_410a_id = query_410a_id[0][0]
+    else:
+        warn("Creating the tag '410__a', which doesn't exist")
+        tag_410a_id = run_sql(
+            """INSERT INTO tag SET name='410__a', value='410__a')"""
+        )
+
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 50)""",
+        (field_id, tag_371x_id)
+    )
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 50)""",
+        (field_id, tag_110x_id)
+    )
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 50)""",
+        (field_id, tag_410a_id)
+    )
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 50)""",
+        (field_id, tag_410g_id)
+    )
+
+
+def estimate():
+    return 1
+
+
+def pre_upgrade():
+    pass
+
+
+def post_upgrade():
+    pass

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -5102,4 +5102,6 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2013_11_28_bibauthorid_s
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_04_01_new_aidAFFILIATIONS',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_01_23_bibauthorid_rabbit_matchable_name_column', NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_05_26_new_index_country',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_06_new_field_note',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_10_new_field_address',NOW());
 -- end of file

--- a/modules/miscutil/sql/tabfill.sql
+++ b/modules/miscutil/sql/tabfill.sql
@@ -64,6 +64,8 @@ INSERT INTO field VALUES (41,'cited by excluding self cites','citedbyexcludingse
 INSERT INTO field VALUES (42,'cataloguer nickname','cataloguer');
 INSERT INTO field VALUES (43,'file name','filename');
 INSERT INTO field VALUES (44,'country','country');
+INSERT INTO field VALUES (45,'note','note');
+INSERT INTO field VALUES (46,'address','address');
 
 INSERT INTO field_tag VALUES (10,11,100);
 INSERT INTO field_tag VALUES (11,14,100);
@@ -288,6 +290,13 @@ INSERT INTO field_tag VALUES (44,227,10);
 INSERT INTO field_tag VALUES (44,228,10);
 INSERT INTO field_tag VALUES (44,229,10);
 INSERT INTO field_tag VALUES (44,230,10);
+-- address fields
+INSERT INTO field_tag VALUES (45,231,10);
+INSERT INTO field_tag VALUES (46,232,10);
+INSERT INTO field_tag VALUES (46,233,10);
+INSERT INTO field_tag VALUES (46,234,10);
+INSERT INTO field_tag VALUES (46,149,10);
+
 
 INSERT INTO format (id,name,code,description,content_type,visibility) VALUES (1,'HTML brief','hb', 'HTML brief output format, used for search results pages.', 'text/html', 1);
 INSERT INTO format (id,name,code,description,content_type,visibility) VALUES (2,'HTML detailed','hd', 'HTML detailed output format, used for Detailed record pages.', 'text/html', 1);
@@ -553,6 +562,12 @@ INSERT INTO tag VALUES (227,'SPIRES name','110__u','');
 INSERT INTO tag VALUES (228,'country name','371__d','');
 INSERT INTO tag VALUES (229,'country code','371__g','');
 INSERT INTO tag VALUES (230,'extra','371__x','');
+--
+INSERT INTO tag VALUES (231,'note', '500__a','');
+INSERT INTO tag VALUES (232,'address', '371__%','');
+INSERT INTO tag VALUES (233,'110__(any)', '110__%','');
+INSERT INTO tag VALUES (234,'410__g', '410__g','');
+
 
 INSERT INTO idxINDEX VALUES (1,'global','This index contains words/phrases from global fields.','0000-00-00 00:00:00', '', 'native', 'INDEX-SYNONYM-TITLE,exact','No','No','No','BibIndexDefaultTokenizer');
 INSERT INTO idxINDEX VALUES (2,'collection','This index contains words/phrases from collection identifiers fields.','0000-00-00 00:00:00', '', 'native', '','No','No','No', 'BibIndexDefaultTokenizer');

--- a/modules/websearch/lib/search_engine_query_parser.py
+++ b/modules/websearch/lib/search_engine_query_parser.py
@@ -465,8 +465,8 @@ class SpiresToInvenioSyntaxConverter:
         'collab-name' : 'collaboration:',
         'cn' : 'collaboration:',
         # conference number
-        'conf-number' : '111__g:',
-        'cnum' : '773__w:',
+        'conf-number' : 'confnumber:',
+        'cnum' : 'confnumber:',
         # country
         'cc' : 'country:',
         'country' : 'country:',
@@ -523,7 +523,7 @@ class SpiresToInvenioSyntaxConverter:
         'keywords' : 'keyword:',
         'kw' : 'keyword:',
         # note
-        'note' : '500__a:',
+        'note' : 'note:',
         # old title
         'old-title' : '246__a:',
         'old-t' : '246__a:',
@@ -572,7 +572,7 @@ class SpiresToInvenioSyntaxConverter:
         'parx' : '037__c:',
         'primarch' : '037__c:',
         # texkey
-        'texkey' : '035__%:',
+        'texkey' : 'texkey:',
         # type code
         'tc' : 'collection:',
         'ty' : 'collection:',
@@ -614,8 +614,8 @@ class SpiresToInvenioSyntaxConverter:
         'exact-exp' : '',
         'exact-expno' : '',
         # hidden note
-        'hidden-note' : '',
-        'hn' : '',
+        'hidden-note' : '595:',
+        'hn' : '595:',
         # ppf
         'ppf' : '',
         'ppflist' : '',
@@ -641,11 +641,11 @@ class SpiresToInvenioSyntaxConverter:
         #'cited:', # topcite is technically a phrase index - this isn't necessary
         '773__y:', # journal-year
         '773__c:', # journal-page
-        '773__w:', # cnum
-        'country:', # country code
+        'confnumber:', # cnum
+        'country:', # country code and country name
         'subject:', # field code
         'collection:', # type code
-        '035__z:', # texkey
+        'texkey:', # texkey
         # also exact expno, corp-auth, url, abstract, doi, mycite, citing
         # but we have no invenio equivalents for these ATM
     ]

--- a/modules/websearch/lib/search_engine_query_parser_unit_tests.py
+++ b/modules/websearch/lib/search_engine_query_parser_unit_tests.py
@@ -1115,6 +1115,72 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
             spi_search = 'find country Italy'
             self._compare_searches(inv_search, spi_search)
 
+        def test_find_conf_number_123(self):
+            """SPIRES and invenio search syntax - find conf-number 123"""
+            combo_search = 'find conf-number 123'
+            inv_search = 'confnumber:123'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_cnum_123(self):
+            """SPIRES and invenio search syntax - find cnum 123"""
+            combo_search = 'find cnum 123'
+            inv_search = 'confnumber:123'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_conf_number_123_456(self):
+            """SPIRES and invenio search syntax - find conf-number 123 456"""
+            combo_search = 'find conf-number 123 456'
+            inv_search = 'confnumber:"123 456"'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_country_Switzerland(self):
+            """SPIRES and invenio search syntax - find country Switzerland"""
+            combo_search = 'find country Switzerland'
+            inv_search = 'country:Switzerland'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_cc_Switzerland(self):
+            """SPIRES and invenio search syntax - find cc Switzerland"""
+            combo_search = 'find cc Switzerland'
+            inv_search = 'country:Switzerland'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_country_United_States(self):
+            """SPIRES and invenio search syntax - find country United States"""
+            combo_search = 'find country United States'
+            inv_search = 'country:"United States"'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_note_blabla(self):
+            """SPIRES and invenio search syntax - find note blabla"""
+            combo_search = 'find note blabla'
+            inv_search = 'note:blabla'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_texkey_blabla(self):
+            """SPIRES and invenio search syntax - find texkey blabla"""
+            combo_search = 'find texkey blabla'
+            inv_search = 'texkey:blabla'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_texkey_bla_space_bla(self):
+            """SPIRES and invenio search syntax - find texkey bla space bla"""
+            combo_search = 'find texkey bla space bla'
+            inv_search = 'texkey:"bla space bla"'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_address_Geneva(self):
+            """SPIRES and invenio search syntax - find address Geneva"""
+            combo_search = 'find address Geneva'
+            inv_search = 'address:Geneva'
+            self._compare_searches(inv_search, combo_search)
+
+        def test_find_hidden_note_bla(self):
+            """SPIRES and invenio search syntax - find hidden-note bla"""
+            combo_search = 'find hidden-note bla'
+            inv_search = '595:bla'
+            self._compare_searches(inv_search, combo_search)
+
     if CFG_WEBSEARCH_SPIRES_SYNTAX > 1:
         def test_absorbs_naked_a_search(self):
             """SPIRES search syntax - a ellis"""


### PR DESCRIPTION
- Edits _SPIRES_TO_INVENIO_KEYWORDS_MATCHINGS and
  _INVENIO_KEYWORDS_FOR_SPIRES_PHRASE_SEARCHES in search_engine_parser.py
- Adds unit tests for the new mappings
- Adds new 'address' field and relative tag mapping (in tabfill and with a new
  upgrade script)
- Adds new 'note' field and relative tag mapping (in tabfill and with a new
  upgrade script)

Signed-off-by: Federico Poli federico.poli@cern.ch
