### PR TITLE
BibIndex: new `datasource` field and `786__w` tag

### DIFF
--- a/modules/bibfield/etc/atlantis.cfg
+++ b/modules/bibfield/etc/atlantis.cfg
@@ -1393,3 +1393,20 @@ number_of_citations:
     calculated:
         @parse_first(('recid', ))
         get_cited_by_count(self.get('recid'))
+
+data_source:
+    creator:
+        @legacy((("786", "786__", "786__%"), ""),
+                ("786__w", "control number"),
+                ("786__a", "main heading"),
+                ("786__t", "title"),
+                ("786__v", "attribution"))
+        marc, "786__", {"control number": value["w"],
+                        "main heading": value["a"],
+                        "title": value["t"],
+                        "attribution": value["v"]}
+    producer:
+        json_for_marc(), {"786__w": "control number",
+                          "786__a": "main heading",
+                          "786__t": "title",
+                          "786__v": "attribution"}

--- a/modules/miscutil/lib/upgrades/invenio_2014_06_11_new_field_datasource.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_06_11_new_field_datasource.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "New datasource field."
+
+
+def do_upgrade():
+    """ Perform upgrade """
+    pass
+
+
+def do_upgrade_atlantis():
+    """ Perform upgrade """
+    field_id = run_sql(
+        """INSERT INTO field SET name='data source', code='datasource'"""
+    )
+    tag_id = run_sql(
+        """INSERT INTO tag SET name='data source', value='786__w'"""
+    )
+    run_sql(
+        """INSERT INTO field_tag VALUES (%s, %s, 10)""",
+        (field_id, tag_id)
+    )
+
+
+def estimate():
+    """ Return estimate of upgrade time in seconds """
+    return 1

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -5104,4 +5104,5 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_01_23_bibauthorid_r
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_05_26_new_index_country',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_06_new_field_note',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_10_new_field_address',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_11_new_field_datasource',NOW());
 -- end of file

--- a/modules/miscutil/sql/tabfill.sql
+++ b/modules/miscutil/sql/tabfill.sql
@@ -66,6 +66,7 @@ INSERT INTO field VALUES (43,'file name','filename');
 INSERT INTO field VALUES (44,'country','country');
 INSERT INTO field VALUES (45,'note','note');
 INSERT INTO field VALUES (46,'address','address');
+INSERT INTO field VALUES (47,'data source','datasource');
 
 INSERT INTO field_tag VALUES (10,11,100);
 INSERT INTO field_tag VALUES (11,14,100);
@@ -296,7 +297,8 @@ INSERT INTO field_tag VALUES (46,232,10);
 INSERT INTO field_tag VALUES (46,233,10);
 INSERT INTO field_tag VALUES (46,234,10);
 INSERT INTO field_tag VALUES (46,149,10);
-
+--
+INSERT INTO field_tag VALUES (47,235,10);
 
 INSERT INTO format (id,name,code,description,content_type,visibility) VALUES (1,'HTML brief','hb', 'HTML brief output format, used for search results pages.', 'text/html', 1);
 INSERT INTO format (id,name,code,description,content_type,visibility) VALUES (2,'HTML detailed','hd', 'HTML detailed output format, used for Detailed record pages.', 'text/html', 1);
@@ -567,7 +569,8 @@ INSERT INTO tag VALUES (231,'note', '500__a','');
 INSERT INTO tag VALUES (232,'address', '371__%','');
 INSERT INTO tag VALUES (233,'110__(any)', '110__%','');
 INSERT INTO tag VALUES (234,'410__g', '410__g','');
-
+--
+INSERT INTO tag VALUES (235,'data source','786__w','');
 
 INSERT INTO idxINDEX VALUES (1,'global','This index contains words/phrases from global fields.','0000-00-00 00:00:00', '', 'native', 'INDEX-SYNONYM-TITLE,exact','No','No','No','BibIndexDefaultTokenizer');
 INSERT INTO idxINDEX VALUES (2,'collection','This index contains words/phrases from collection identifiers fields.','0000-00-00 00:00:00', '', 'native', '','No','No','No', 'BibIndexDefaultTokenizer');


### PR DESCRIPTION
- Adds field `datasource`, associated with the new tag `786__w`
- Adds upgrade script
- Adds bibfield definition of `datasource` in `atlantis.cfg`

Signed-off-by: Federico Poli federico.poli@cern.ch
