### PR TITLE
BibAuthorID: Handling of timeouts when connecting to crossref.

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_general_utils.py
+++ b/modules/bibauthorid/lib/bibauthorid_general_utils.py
@@ -46,6 +46,9 @@ import random
 from collections import Hashable
 from functools import partial
 
+import socket
+from urllib2 import URLError
+
 import os
 PID = os.getpid
 
@@ -324,8 +327,14 @@ def is_arxiv_id_or_doi(identifier):
 def get_title_of_doi(doi):
     try:
         xml = get_marcxml_for_doi(doi)
-    except CrossrefError:
+    except (CrossrefError, socket.timeout):
         return doi
+    except URLError, e:
+    # For python 2.6 socket.timeout cannot be caught directly    
+        if isinstance(e.reason, socket.timeout):
+            return doi
+        else:  # We make sure we don't cut out other URLErrors.
+            raise
 
     root = ET.fromstring(xml)
 


### PR DESCRIPTION
This is necessary to prevent the webauthorprofile daemon crashing because of a timeout when trying to get an external publication's name. Since this is just a title, @WohthaN suggested that we shouldn't really try so hard to get the name of a paper, as it will keep the daemon running for quite a while. Instead, in case of timeout we display a linkable doi.

Moreover, @jalavik suggested we should make `get_marcxml_for_doi` (in crossrefutils) handle (or propagate) timeouts for all clients with a potential benefit to all clients.
