### PR TITLE
BibIndex: do not use hstRECORD

### DIFF
--- a/modules/bibindex/lib/bibindex_engine.py
+++ b/modules/bibindex/lib/bibindex_engine.py
@@ -507,8 +507,9 @@ def find_affected_records_for_index(indexes=[], recIDs=[], force_all_indexes=Fal
         all_recIDs = []
         for recIDs_range in recIDs:
             all_recIDs.extend(range(recIDs_range[0], recIDs_range[1]+1))
-        for index in indexes:
-            records_for_indexes[index] = all_recIDs
+        if all_recIDs:
+            for index in indexes:
+                records_for_indexes[index] = all_recIDs
         return records_for_indexes
 
     min_last_updated = get_min_last_updated(indexes)[0][0] or \
@@ -2135,11 +2136,16 @@ def task_run_core():
 
     # regular index: initialization for Words,Pairs,Phrases
     recIDs_range = get_recIDs_from_cli(regular_indexes)
+    # FIXME: restore when the hstRECORD table race condition between
+    #        bibupload and bibindex is solved
+    # recIDs_for_index = find_affected_records_for_index(regular_indexes,
+    #                                                    recIDs_range,
+    #                                                    (task_get_option("force") or \
+    #                                                    task_get_option("reindex") or \
+    #                                                    task_get_option("cmd") == "del"))
     recIDs_for_index = find_affected_records_for_index(regular_indexes,
                                                        recIDs_range,
-                                                       (task_get_option("force") or \
-                                                       task_get_option("reindex") or \
-                                                       task_get_option("cmd") == "del"))
+                                                       True)
 
     if len(recIDs_for_index.keys()) == 0:
         write_message("Selected indexes/recIDs are up to date.")

--- a/modules/bibindex/lib/bibindex_regression_tests.py
+++ b/modules/bibindex/lib/bibindex_regression_tests.py
@@ -1251,8 +1251,6 @@ class BibIndexFindingAffectedIndexes(InvenioTestCase):
         self.assertRaises(KeyError, lambda :records_for_indexes["title"])
 
 
-
-
 class BibIndexIndexingAffectedIndexes(InvenioTestCase):
 
     started = False

--- a/modules/bibindex/lib/bibindex_regression_tests.py
+++ b/modules/bibindex/lib/bibindex_regression_tests.py
@@ -1899,11 +1899,9 @@ class BibIndexVirtualIndexQueueTableTest(InvenioTestCase):
     """Tests communication through Queue tables between virtual index and
        dependent indexes"""
 
-
     @classmethod
     def index_dependent_index(self, index_name, records_range, table_type):
         """indexes a dependent index for given record range"""
-        index_id = get_index_id_from_index_name(index_name)
         wordTable = WordTable(index_name=index_name,
                               table_type=table_type,
                               wash_index_terms=50)
@@ -1917,54 +1915,91 @@ class BibIndexVirtualIndexQueueTableTest(InvenioTestCase):
 
     def test_1_correct_entry_in_queue_for_word_table(self):
         """bibindex - checks correct entry in queue table for words"""
-        self.index_dependent_index('title', [[10,14]], CFG_BIBINDEX_INDEX_TABLE_TYPE["Words"])
-        query = "SELECT * FROM idxWORD01Q"
-        res = run_sql(query)
-        self.assertEqual((10, 14), (res[0][2], res[0][3]))
-        self.run_update_for_virtual_index(CFG_BIBINDEX_INDEX_TABLE_TYPE["Words"])
+        index_name = 'title'
+        table_type = CFG_BIBINDEX_INDEX_TABLE_TYPE["Words"]
+        # Add records to queue
+        self.index_dependent_index(index_name, [[10, 14]], table_type)
+        # Get content of queue
+        queue = run_sql(
+            """SELECT id_bibrec_low, id_bibrec_high, index_name, mode
+            FROM idx%s01Q""" % table_type
+        )
+        # Clean the queue
+        self.run_update_for_virtual_index(table_type)
+        # Check queue content
+        self.assertEqual(((10, 14, index_name, 'update'),), queue)
 
     def test_2_correct_entry_in_queue_for_pair_table(self):
         """bibindex - checks correct entry in queue table for pairs"""
-        self.index_dependent_index('collection', [[1,5],[20,21]], CFG_BIBINDEX_INDEX_TABLE_TYPE["Pairs"])
-        query = "SELECT * FROM idxPAIR01Q ORDER BY runtime,id DESC"
-        res = run_sql(query)
-        self.assertEqual(2, len(res))
-        self.assertEqual((20, 21), (res[0][2], res[0][3]))
-        self.assertEqual('update', res[0][5])
-        self.run_update_for_virtual_index(CFG_BIBINDEX_INDEX_TABLE_TYPE["Pairs"])
+        index_name = 'collection'
+        table_type = CFG_BIBINDEX_INDEX_TABLE_TYPE["Pairs"]
+        # Add records to queue
+        self.index_dependent_index(index_name, [[1, 5], [20, 21]], table_type)
+        # Get content of queue
+        queue = run_sql(
+            """SELECT id_bibrec_low, id_bibrec_high, index_name, mode
+            FROM idx%s01Q""" % table_type
+        )
+        # Clean the queue
+        self.run_update_for_virtual_index(table_type)
+        # Check queue content
+        expected = [
+            (1, 5, index_name, 'update'),
+            (20, 21, index_name, 'update')
+        ]
+        self.assertEqual(expected, sorted(queue))
 
     def test_3_correct_entry_in_queue_for_phrase_table(self):
         """bibindex - checks correct entry in queue table for phrases"""
-        self.index_dependent_index('keyword', [[19,19]], CFG_BIBINDEX_INDEX_TABLE_TYPE["Phrases"])
-        query = "SELECT * FROM idxPHRASE01Q"
-        res = run_sql(query)
-        self.assertEqual((19, 19), (res[0][2], res[0][3]))
-        self.assertEqual('keyword', res[0][4])
-        self.run_update_for_virtual_index(CFG_BIBINDEX_INDEX_TABLE_TYPE["Phrases"])
+        index_name = 'keyword'
+        table_type = CFG_BIBINDEX_INDEX_TABLE_TYPE["Phrases"]
+        # Add records to queue
+        self.index_dependent_index(index_name, [[19, 19]], table_type)
+        # Get content of queue
+        queue = run_sql(
+            """SELECT id_bibrec_low, id_bibrec_high, index_name, mode
+            FROM idx%s01Q""" % table_type
+        )
+        # Clean the queue
+        self.run_update_for_virtual_index(table_type)
+        # Check queue content
+        self.assertEqual(((19, 19, index_name, 'update'),), queue)
 
     def test_4_no_entries_in_queue_table(self):
         """bibindex - checks if virtual index removes entries from queue table after update"""
-        query = "SELECT * FROM idxWORD01Q"
-        res = run_sql(query)
-        empty = tuple()
-        self.assertEqual(empty, res)
+        table_type = CFG_BIBINDEX_INDEX_TABLE_TYPE["Words"]
+        # Add records to queue
+        self.index_dependent_index('title',      [[10, 14]], table_type)
+        self.index_dependent_index('collection', [[20, 21]], table_type)
+        self.index_dependent_index('keyword',    [[14, 23]], table_type)
+        # Update the virtual index and flush queue table for words
+        self.run_update_for_virtual_index(table_type)
+        # After running the update the queue table for words MUST be empty
+        res = run_sql("SELECT * FROM idx%s01Q" % table_type)
+        self.assertEqual(tuple(), res)
 
     def test_5_remove_duplicates_in_queue_table(self):
         """bibindex - checks if duplicates are removed"""
         index_name = 'title'
         table_type = CFG_BIBINDEX_INDEX_TABLE_TYPE["Words"]
-        self.index_dependent_index(index_name, [[10,14]], table_type)
-        self.index_dependent_index(index_name, [[20,23]], table_type)
-        self.index_dependent_index(index_name, [[10,14]], table_type)
-        query = """SELECT id_bibrec_low, id_bibrec_high, mode FROM idx%s01Q
-                   WHERE index_name='%s' ORDER BY runtime ASC""" % (table_type, index_name)
-        entries_before = run_sql(query)
+        # Add records to queue
+        self.index_dependent_index(index_name, [[10, 14]], table_type)
+        self.index_dependent_index(index_name, [[20, 23]], table_type)
+        self.index_dependent_index(index_name, [[10, 14]], table_type)
+        # Get queue
+        entries_before = run_sql(
+            """SELECT id_bibrec_low, id_bibrec_high, mode FROM idx%s01Q
+            ORDER BY runtime ASC""" % table_type
+        )
+        # Remove duplicates
         vit = VirtualIndexTable('global', table_type)
         entries_after = vit.remove_duplicates(entries_before)
+        # Update the virtual index and flush queue table for words
+        self.run_update_for_virtual_index(table_type)
+        # Check queue content
         self.assertEqual(len(entries_before), 3)
         self.assertEqual(len(entries_after), 2)
-        self.assertTrue(entries_before[1] == entries_after[1])
-        self.run_update_for_virtual_index(table_type)
+        self.assertEqual(entries_before[1], entries_after[1])
 
 
 class BibIndexSpecialTagsTest(InvenioTestCase):

--- a/modules/bibindex/lib/bibindex_regression_tests.py
+++ b/modules/bibindex/lib/bibindex_regression_tests.py
@@ -1778,6 +1778,7 @@ class BibIndexCLICallTest(InvenioTestCase):
     def test_correct_message_for_up_to_date_indexes(self):
         """bibindex - checks if correct message for index up to date appears"""
         index_name = "abstract"
+        reindex_for_type_with_bibsched(index_name)
         task_id = reindex_for_type_with_bibsched(index_name)
         filename = task_log_path(task_id, 'log')
         fl = open(filename)
@@ -1919,6 +1920,15 @@ class BibIndexCommonWordsInVirtualIndexTest(InvenioTestCase):
 class BibIndexVirtualIndexQueueTableTest(InvenioTestCase):
     """Tests communication through Queue tables between virtual index and
        dependent indexes"""
+
+    @classmethod
+    def setUpClass(cls):
+        # Clean the queue table, because some test did not it before
+        # FIXME: remove when restoring hstRECORD table utilization in bibindex
+        for table_type in ["Words", "Pairs", "Phrases"]:
+            cls.run_update_for_virtual_index(
+                CFG_BIBINDEX_INDEX_TABLE_TYPE[table_type]
+            )
 
     @classmethod
     def index_dependent_index(self, index_name, records_range, table_type):


### PR DESCRIPTION
##### BibIndex: improve virtual index queue tests
- Refactors the regression test `BibIndexVirtualIndexQueueTableTest`,
  in order to keep the queue table clean even if a test fails.

Signed-off-by: Federico Poli federico.poli@cern.ch

---
##### BibUpload: factor out step 6
- Move out the job end dates updating in a separate function
  to be able to call it in tests.

---
##### BibIndex: test concurrent bibupload and bibindex

---
##### BibIndex: do not use hstRECORD …
- Disables the filtering step that uses `hstRECORD` table:
  set always `force_all_indexes=True` when calling
  `find_affected_records_for_index`
- Fixes `find_affected_records_for_index` when called with `recIDs=[]`
- Fixes some regression test that relied on the utilization of
  `hstRECORD` in BibIndex

Signed-off-by: Federico Poli federico.poli@cern.ch
