### PR TITLE
sequtils: robust cnum generation

### DIFF
--- a/modules/miscutil/lib/sequtils_cnum.py
+++ b/modules/miscutil/lib/sequtils_cnum.py
@@ -89,7 +89,7 @@ class CnumSeq(SequenceGenerator):
         record_cnums = self._get_record_cnums(base_cnum)
         if not record_cnums:
             new_cnum = base_cnum
-        elif len(record_cnums) == 1:
+        elif len(record_cnums) == 1 and '.' not in record_cnums[0]:
             new_cnum = base_cnum + '.' + '1'
         else:
             # Get the max current revision, cnums are in format Cyy-mm-dd,


### PR DESCRIPTION
- Implements more robust cnum generation by not assuming that, if only
  1 cnum is found in the seqSTORE with a given base, it doesn't already
  have version as a suffix.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
