### PR TITLE
WebSearch: journal hint service utf8 fix

### DIFF
--- a/modules/docextract/lib/refextract_unit_tests.py
+++ b/modules/docextract/lib/refextract_unit_tests.py
@@ -248,6 +248,15 @@ class SearchTest(InvenioTestCase):
         self.assert_('B76' in pattern)
         self.assert_('477' in pattern)
 
+    def test_not_recognized_unicode_1(self):
+        field, pattern = search_from_reference(u'País Valencià')
+        self.assertEqual(field, '')
+        self.assertEqual(pattern, '')
+
+    def test_not_recognized_unicode_2(self):
+        field, pattern = search_from_reference(u'Capellà Pere')
+        self.assertEqual(field, '')
+        self.assertEqual(pattern, '')
 
 class RebuildReferencesTest(InvenioTestCase):
     def setUp(self):

--- a/modules/websearch/lib/services/JournalHintService.py
+++ b/modules/websearch/lib/services/JournalHintService.py
@@ -57,7 +57,7 @@ class JournalHintService(SearchService):
         if re_keyword_at_beginning.match(p):
             return (0, "")
 
-        (field, pattern) = search_from_reference(p)
+        (field, pattern) = search_from_reference(p.decode('utf-8'))
 
         if field is not "journal":
             return (0, "")

--- a/modules/websearch/lib/websearch_services_regression_tests.py
+++ b/modules/websearch/lib/websearch_services_regression_tests.py
@@ -440,6 +440,29 @@ class WebSearchServicesJournalHintService(InvenioTestCase):
         self.assert_(response[0] >=50)
         self.assert_('journal:"Phys. Rev. D40 (1989) 1753"' in response[1])
 
+    def test_search_Capella_Pere_utf8(self):
+        """websearch - search 'Capellà Pere' utf8, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = u'Capellà Pere'.encode('utf8')
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Pais_Valencia_utf8(self):
+        """websearch - search 'País Valencià' utf8, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = u'País Valencià'.encode('utf8')
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+
 TEST_SUITE = make_test_suite(WebSearchServicesLoading,
                              WebSearchServicesCollectionNameSearch,
                              WebSearchServicesSubmissionNameSearch,


### PR DESCRIPTION
- Fixes journal hint service: decodes utf8 before passing the query
  to `search_from_reference`
- Adds two unit tests to `search_from_reference`, just to be sure that it
  accepts unicode

Signed-off-by: Federico Poli feedrico.poli@cern.ch
