### PR TITLE
WebSearch: quick checks in journal hint service

### DIFF
--- a/modules/docextract/lib/refextract_unit_tests.py
+++ b/modules/docextract/lib/refextract_unit_tests.py
@@ -258,6 +258,7 @@ class SearchTest(InvenioTestCase):
         self.assertEqual(field, '')
         self.assertEqual(pattern, '')
 
+
 class RebuildReferencesTest(InvenioTestCase):
     def setUp(self):
         setup_loggers(verbosity=1)

--- a/modules/websearch/lib/Makefile.am
+++ b/modules/websearch/lib/Makefile.am
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -48,6 +48,7 @@ pylib_DATA = \
 	websearch_external_collections_unit_tests.py \
 	websearch_external_collections_utils.py \
 	websearch_services.py \
+	websearch_services_unit_tests.py \
 	websearch_services_regression_tests.py \
     search_engine_summarizer_regression_tests.py
 

--- a/modules/websearch/lib/websearch_services_unit_tests.py
+++ b/modules/websearch/lib/websearch_services_unit_tests.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""WebSearch services unit tests."""
+
+__revision__ = "$Id$"
+
+import os
+
+from invenio.testutils import InvenioTestCase, make_test_suite, run_test_suite
+from invenio.pluginutils import PluginContainer
+from invenio.websearch_services import (
+    CFG_SEARCH_SERVICES_PATH,
+    __required_plugin_API_version__,
+    SearchService
+)
+
+
+class WebSearchServicesJournalHintService(InvenioTestCase):
+
+    """Check JournalHintService plugin."""
+
+    def setUp(self):
+        """Load plugin."""
+        search_service_plugins = PluginContainer(
+            os.path.join(CFG_SEARCH_SERVICES_PATH, '*Service.py'),
+            api_version=__required_plugin_API_version__,
+            plugin_signature=SearchService
+        )
+        self.plugin = search_service_plugins.get('JournalHintService')()
+
+    def test_seems_a_journal_reference(self):
+        """Check function JournalHintService.seems_a_journal_reference."""
+        test_pairs = [
+            # Empty strings
+            ("", False),
+            (" ", False),
+            ("\t", False),
+            ("\t \t", False),
+            # Invenio and Inspire queries
+            ("author:Tom", False),
+            ("find a John", False),
+            ("find date after 2001", False),
+            ("year:2001 OR year:2002", False),
+            # Invalid journals with bad format
+            ("Monkey", False),
+            ("Monkey monkey", False),
+            ("Monkey monkey (1)", False),
+            ("Monkey monkey 1234", False),
+            # Invalid journals with good format
+            ("Monkey monkey, 1234", True),
+            ("Monkey (2000)", True),
+            # Invalid journals with good format, utf8
+            (u"Capellà Pere (2000)".encode("utf8"), True),
+            (u"País Valencià, 1234".encode("utf8"), True),
+            # Valid journal with good format
+            ("JHEP 9906:028 (1999)", True),
+            ("Phys. Rev. Lett. 83 (1999) 3605", True),
+            ("Nucl.Phys.,B75,(1974),461", True),
+            ("  Nucl.  Phys.   B75   (1974)  461   ", True),
+            ("D.S. Salopek, J.R.Bond and J.M.Bardeen,Phys.Rev.D40(1989)1753.",
+             True),
+        ]
+
+        for test_input, expected in test_pairs:
+            test_output = self.plugin.seems_a_journal_reference(test_input)
+            self.assertEqual(
+                test_output,
+                expected,
+                "JournalHintService.seems_a_journal_reference('%s') "
+                "returned '%s' instead of '%s'"
+                % (repr(test_input), repr(test_output), repr(expected))
+            )
+
+
+TEST_SUITE = make_test_suite()
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- Adds a quick `seems_a_journal_reference` function to the journal hint 
  web service                                                           
- Adds unit tests for `seems_a_journal_reference`

Signed-off-by: Federico Poli federico.poli@cern.ch
