### PR TITLE
WebLinkback: reliable linkback sorting

### DIFF
--- a/modules/weblinkback/lib/weblinkback_dblayer.py
+++ b/modules/weblinkback/lib/weblinkback_dblayer.py
@@ -187,7 +187,7 @@ def get_approved_latest_added_linkbacks(count):
                              insert_time
                       FROM lnkENTRY
                       WHERE status=%s
-                      ORDER BY insert_time DESC
+                      ORDER BY insert_time DESC, id DESC
                       LIMIT %s
                    """, (CFG_WEBLINKBACK_STATUS['APPROVED'], count))
 

--- a/modules/weblinkback/lib/weblinkback_regression_tests.py
+++ b/modules/weblinkback/lib/weblinkback_regression_tests.py
@@ -438,11 +438,11 @@ class WebLinkbackDatabaseTest(InvenioTestCase):
 
         approved_linkbacks = get_approved_latest_added_linkbacks(6)
         self.assertEqual(5, len(approved_linkbacks))
-        self.assertEqual(1 + self._max_id_lnkENTRY, approved_linkbacks[0][0])
-        self.assertEqual(2 + self._max_id_lnkENTRY, approved_linkbacks[1][0])
+        self.assertEqual(1 + self._max_id_lnkENTRY, approved_linkbacks[4][0])
+        self.assertEqual(2 + self._max_id_lnkENTRY, approved_linkbacks[3][0])
         self.assertEqual(5 + self._max_id_lnkENTRY, approved_linkbacks[2][0])
-        self.assertEqual(6 + self._max_id_lnkENTRY, approved_linkbacks[3][0])
-        self.assertEqual(7 + self._max_id_lnkENTRY, approved_linkbacks[4][0])
+        self.assertEqual(6 + self._max_id_lnkENTRY, approved_linkbacks[1][0])
+        self.assertEqual(7 + self._max_id_lnkENTRY, approved_linkbacks[0][0])
 
         url = CFG_SITE_URL + '/linkbacks/'
         expected_texts = ('URL1', 'URL2', 'URL5', 'URL6', 'URL7')


### PR DESCRIPTION
- Order linkbacks by id when they have the same insert date in
  test_get_approved_latest_added_linkback so that tests pass reliably.
