### PR TITLE
BibAuthorID: integration with BibCatalog

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -1816,7 +1816,6 @@ def update_request_ticket_for_author(pid, ticket_dict, tid=None):  # update_requ
                values (%s, %s, %s, %s)""",
            (pid, 'request_tickets', request_tickets, request_tickets_num))
 
-
 def remove_request_ticket_for_author(pid, tid=None):  # delete_request_ticket
     '''
     Removes a request ticket from the given author. If ticket identifier is not
@@ -1857,7 +1856,7 @@ def remove_request_ticket_for_author(pid, tid=None):  # delete_request_ticket
     run_sql("""insert into aidPERSONIDDATA
                (personid, tag, datablob, opt1)
                values (%s, %s, %s, %s)""",
-           (pid, 'request_tickets', request_tickets, request_tickets_num))
+            (pid, 'request_tickets', request_tickets, request_tickets_num))
 
 
 def modify_canonical_name_of_authors(pids_newcnames=None):  # change_personID_canonical_names

--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -1816,6 +1816,30 @@ def update_request_ticket_for_author(pid, ticket_dict, tid=None):  # update_requ
                values (%s, %s, %s, %s)""",
            (pid, 'request_tickets', request_tickets, request_tickets_num))
 
+
+def remove_rtid_from_ticket(rtid, pid):
+    '''
+    Remove rtid from ticket blob in aidPERSONIDDATA.
+    '''
+    request_tickets = get_request_tickets_for_author(pid)
+    request_tickets_exist = bool(request_tickets)
+
+    for request_ticket in request_tickets:
+        if request_ticket['rtid'] == rtid:
+            request_ticket.pop('rtid')
+            break
+
+    request_tickets_num = len(request_tickets)
+    request_tickets = serialize(request_tickets)
+
+    if request_tickets_exist:
+        remove_request_ticket_for_author(pid)
+
+    run_sql("""insert into aidPERSONIDDATA
+               (personid, tag, datablob, opt1)
+               values (%s, %s, %s, %s)""",
+            (pid, 'request_tickets', request_tickets, request_tickets_num))
+
 def remove_request_ticket_for_author(pid, tid=None):  # delete_request_ticket
     '''
     Removes a request ticket from the given author. If ticket identifier is not

--- a/modules/bibauthorid/lib/bibauthorid_templates.py
+++ b/modules/bibauthorid/lib/bibauthorid_templates.py
@@ -1091,6 +1091,7 @@ class Template:
                 email = self._('Not provided')
                 date = self._('Not Available')
                 actions = []
+                rtid = None
 
                 for info in t[0]:
                     if info[0] == 'firstname':
@@ -1107,6 +1108,9 @@ class Template:
                         date = info[1]
                     elif info[0] in ['assign', 'reject']:
                         actions.append(info)
+                    elif info[0] == 'rtid':
+                        rtid = info[1]
+
 
                 if 'delete' in ticket_links:
                     h(('<strong>Ticket number: %(tnum)s </strong> <a rel="nofollow" id="cancel" href=%(url)s/author/claim/action?cancel_rt_ticket=True&selection=%(tnum)s&pid=%(pid)s>' + self._(' Delete this ticket') + ' </a>')
@@ -1152,6 +1156,10 @@ class Template:
 
                     h(' - <a rel="nofollow" id="show_paper" target="_blank" href="%(url)s/record/%(record)s"> View record </a><br>' %
                       ({'url': CFG_SITE_URL, 'record': str(bibrec)}))
+                if rtid:
+                    h('<a rel="nofollow" id="closert" href="%(url)s/author/claim/action?close_rt_ticket=True&rtid=%(rtid)s&pid=%(pid)s">Close this ticket in RT</a>'
+                      % ({'url': CFG_SITE_URL, 'rtid': rtid,
+                          'pid': str(person_id)}))
                 h('</dd>')
                 h('</dd><br>')
                 # h(str(open_rt_tickets))

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -2390,13 +2390,6 @@ def create_request_ticket(userinfo, ticket):
     m("\nLinks to all issued Person-based requests:\n")
 
     for pid, cname in tic:
-        data = list()
-        for i in udata:
-            data.append(i)
-        data.append(['date', ctime()])
-        data.append(['operations', tic[(pid, cname)]])
-
-        dbapi.update_request_ticket_for_author(pid, dict(data))
         m("%s/author/claim/%s?open_claim=True#tabTickets" % (CFG_SITE_URL, cname))
 
     m("\nPlease remember that you have to be logged in "
@@ -2411,13 +2404,23 @@ def create_request_ticket(userinfo, ticket):
             if 'uid' in userinfo:
                 uid = userinfo['uid']
             if 'email' in userinfo:
-                email =  userinfo['email']
+                email = userinfo['email']
 
         rtid = BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
                                                subject="[Author] Change Request for %s" % first_cname,
                                                text="\n".join(mailcontent),
                                                queue="AUTHORS_claim_manual",
                                                requestor=email)
+
+    for pid, cname in tic:
+        data = list()
+        for i in udata:
+            data.append(i)
+        data.append(['date', ctime()])
+        data.append(['operations', tic[(pid, cname)]])
+        data.append(['rtid', rtid])
+
+        dbapi.update_request_ticket_for_author(pid, dict(data))
 
     return True
 

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -48,9 +48,9 @@ from invenio.external_authentication_robot import load_robot_keys
 from invenio.config import CFG_INSPIRE_SITE, CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL, \
     CFG_BIBAUTHORID_ENABLED_REMOTE_LOGIN_SYSTEMS, CFG_WEBAUTHORPROFILE_MAX_HEP_CHOICES, \
     CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL, CFG_BIBUPLOAD_EXTERNAL_OAIID_TAG, \
-    CFG_BIBUPLOAD_EXTERNAL_OAIID_PROVENANCE_TAG, CFG_BIBAUTHORID_ENABLED
+    CFG_BIBUPLOAD_EXTERNAL_OAIID_PROVENANCE_TAG, CFG_BIBAUTHORID_ENABLED, \
+    CFG_TMPSHAREDDIR
 from invenio.config import CFG_SITE_URL
-from invenio.mailutils import send_email
 from invenio.bibauthorid_name_utils import most_relevant_name
 from invenio.bibauthorid_general_utils import is_arxiv_id_or_doi
 from invenio.shellutils import retry_mkstemp
@@ -58,6 +58,7 @@ from invenio.bibrecord import record_xml_output, record_add_field, record_get_fi
     record_get_field_value, record_get_field_values, record_has_field
 from invenio.bibtask import task_low_level_submission
 from invenio.bibauthorid_dbinterface import get_external_ids_of_author, add_arxiv_papers_to_author, get_arxiv_papers_of_author  # pylint: disable-msg=W0614
+from invenio.bibcatalog import BIBCATALOG_SYSTEM
 
 
 #
@@ -2357,6 +2358,8 @@ def create_request_ticket(userinfo, ticket):
 
     m("\nOperations:")
 
+    first_cname = None
+
     tic = dict()
     for op in ticket:
         bibrefrec = op['bibref'] + ',' + str(op['rec'])
@@ -2373,6 +2376,8 @@ def create_request_ticket(userinfo, ticket):
             continue
 
         cname = get_person_redirect_link(op['pid'])
+        if not first_cname:
+            first_cname = cname
 
         try:
             tic[(op['pid'], cname)].append((op['action'], bibrefrec))
@@ -2398,15 +2403,21 @@ def create_request_ticket(userinfo, ticket):
       "in order to see the ticket of a person.\n")
 
     if ticket and tic and mailcontent:
-        sender = CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL
 
-        if bconfig.TICKET_SENDING_FROM_USER_EMAIL and userinfo['email']:
-            sender = userinfo['email']
+        uid = None
+        email = CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL
 
-        send_email(sender,
-                   CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL,
-                   subject="[Author] Change Request",
-                   content="\n".join(mailcontent))
+        if bconfig.TICKET_SENDING_FROM_USER_EMAIL:
+            if 'uid' in userinfo:
+                uid = userinfo['uid']
+            if 'email' in userinfo:
+                email =  userinfo['email']
+
+        rtid = BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                               subject="[Author] Change Request for %s" % first_cname,
+                                               text="\n".join(mailcontent),
+                                               queue="AUTHORS_claim_manual",
+                                               requestor=email)
 
     return True
 
@@ -2432,17 +2443,18 @@ def create_request_message(userinfo, subj=None):
 
     if not subj:
         subj = "[Author] Help Request"
-    send_email(sender,
-               CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL,
-               subject=subj,
-               content="\n".join(mailcontent))
 
+    BIBCATALOG_SYSTEM.ticket_submit(uid=userinfo['uid'],
+                                    subject=subj,
+                                    text="\n".join(mailcontent),
+                                    queue="Authors",
+                                    requestor=sender)
 
-def send_user_commit_notification_email(userinfo, ticket):
+def send_user_commit_notification_email(userinfo, ticket, uid):
     '''
     Sends commit notification email to RT system
     '''
-    # send eMail to RT
+
     mailcontent = []
     m = mailcontent.append
     m("A user committed a change through the web interface.")
@@ -2466,12 +2478,17 @@ def send_user_commit_notification_email(userinfo, ticket):
                     pass
         m(" --- <end> --- \n")
 
+    if userinfo['email']:
+        requestor = userinfo['email']
+    else:
+        requestor = CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL
+
     if ticket and mailcontent:
-        sender = CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL
-        send_email(sender,
-                   CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL,
-                   subject="[Author] NO ACTIONS NEEDED. Changes performed by SSO user.",
-                   content="\n".join(mailcontent))
+        BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                        subject="[Author] NO ACTIONS NEEDED. Changes performed by SSO user.",
+                                        text="\n".join(mailcontent),
+                                        queue="AUTHORS_claim_sso",
+                                        requestor=requestor)
 
     return True
 
@@ -2611,12 +2628,52 @@ def get_orcids_by_pid(pid):
     return tuple(str(x[0]) for x in orcids)
 
 
+def update_hepname_with_orcid(pid, orcid):
+
+    cname = get_person_redirect_link(pid)
+    searchid = '035:"%s"' % cname
+    hepRecord = perform_request_search(rg=0, cc='HepNames', p=' %s ' %
+                                       searchid)[0]
+
+    record = {}
+
+    record_add_field(record,
+                     tag="035",
+                     subfields=[
+                         ('9', "ORCID"),
+                         ('a', str(orcid))
+                     ])
+    record_add_field(record,
+                     tag="001",
+                     controlfield_value=hepRecord)
+
+    record = record_xml_output(record)
+
+    from tempfile import mkstemp
+
+    tmp_file_fd, tmp_file = mkstemp(
+        suffix='.xml',
+        prefix="orcidupdatefile_%s" % strftime("%Y-%m-%d_%H:%M:%S", gmtime()),
+        dir=CFG_TMPSHAREDDIR
+    )
+
+    os.write(tmp_file_fd, record)
+    os.close(tmp_file_fd)
+    os.chmod(tmp_file, 0644)
+
+    task_low_level_submission("bibupload", cname, "-a", tmp_file, "-P5", "-N",
+                              "bibauthorid")
+
+
 def add_orcid_to_pid(pid, orcid):
     if len(get_orcids_by_pid(pid)) > 0:
         return
 
     dbapi.add_orcid_id_to_author(pid, orcid)
     webauthorapi.expire_all_cache_for_personid(pid)
+    # every time an orcid is added to pid we should change the
+    # corresponding hepnames record
+    update_hepname_with_orcid(pid, orcid)
 
 
 def get_person_info_by_pid(pid):
@@ -3265,26 +3322,33 @@ def add_cname_to_hepname_record(cname, recid, uid=None):
     tmp_file.close()
     task_low_level_submission('bibupload', get_nickname(uid) or "", "-a", tmp_file_name, "-P5", "-N", "bibauthorid")
 
-
-def connect_author_with_hepname(cname, hepname):
+def connect_author_with_hepname(cname, hepname, uid):
     subject = "HepNames record match: %s %s" % (cname, hepname)
-    content = "Hello! Please connect the author profile %s " \
-              "with the HepNames record %s. Best regards" % (cname, hepname)
-    send_email(CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL,
-               CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL,
-               subject=subject,
-               content=content)
+    content = "Hello! Please connect the author profile "\
+              "%s/author/profile/%s " \
+              "with the HepNames record "\
+              "%s/record/%s. Best regards" % (CFG_SITE_URL, cname,
+                                               CFG_SITE_URL, hepname)
 
+    BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                    subject=subject,
+                                    text=content,
+                                    queue="Authors",
+                                    recordid=hepname,
+                                    requestor=CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL)
 
-def connect_author_with_orcid(cname, orcid):
+def connect_author_with_orcid(cname, orcid, uid):
     subject = "ORCiD record match: %s %s" % (cname, orcid)
-    content = "Hello! Please connect the author profile %s " \
-              "with the HepNames record %s. Best regards" % (cname, orcid)
-    send_email(CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL,
-               CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL,
-               subject=subject,
-               content=content)
+    content = "Hello! Please connect the author profile " \
+              "%s/author/profile/%s " \
+              "with the Orcid record http://www.orcid.org/%s" \
+              ". Best regards" % (CFG_SITE_URL, cname, orcid)
 
+    BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                    subject=subject,
+                                    text=content,
+                                    queue="Authors",
+                                    requestor=CFG_WEBAUTHORPROFILE_CFG_HEPNAMES_EMAIL)
 
 #
 # Exposed Ticket Functions            #
@@ -3308,10 +3372,12 @@ def construct_operation(operation_parts, pinfo, uid, should_have_bibref=False):
 
     # No bibref specified and no bibref candidates to select from.
     if not bibref and not bibrefs:
-        send_email(CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL,
-                   CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL,
-                   subject="[Author] No authors on record: %s" % rec,
-                   content="No authors seem to exist on record %s" % rec)
+
+        BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                        subject="[Author] No authors on record: %s" % rec,
+                                        text="No authors seem to exist on record %s" % rec,
+                                        queue="Authors",
+                                        requestor=CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL)
         return None
 
     if should_have_bibref and not bibref:
@@ -3337,7 +3403,8 @@ def fill_out_userinfo(additional_info, uid, ip, ulevel, strict_check=True):
                 'comments': additional_info['comments'],
                 'firstname': additional_info['first_name'],
                 'lastname': additional_info['last_name'],
-                'email': additional_info['email']}
+                'email': additional_info['email'],
+                'uid': uid}
 
     if ulevel in ['guest', 'user'] and not userinfo['comments']:
         userinfo['comments'] = 'No comments submitted.'
@@ -3538,7 +3605,7 @@ def _commit_ticket(ticket, userinfo, uid, ulevel):
             create_request_ticket(userinfo, ticket)
 
         if CFG_INSPIRE_SITE and ok_ops:
-            send_user_commit_notification_email(userinfo, ok_ops)
+            send_user_commit_notification_email(userinfo, ok_ops, uid)
 
         for op in ticket:
             op['execution_result'] = {'success': True, 'operation': 'ticketized'}

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -3373,11 +3373,15 @@ def construct_operation(operation_parts, pinfo, uid, should_have_bibref=False):
     # No bibref specified and no bibref candidates to select from.
     if not bibref and not bibrefs:
 
-        BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
-                                        subject="[Author] No authors on record: %s" % rec,
-                                        text="No authors seem to exist on record %s" % rec,
-                                        queue="Authors",
-                                        requestor=CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL)
+        recstruct = get_record(rec)
+        if not record_get_field_value(recstruct, '110', '', '', 'a'):
+
+            BIBCATALOG_SYSTEM.ticket_submit(uid=uid,
+                                            subject="[Author] No authors on record: %s" % rec,
+                                            text="No authors seem to exist on record %s" % rec,
+                                            queue="Authors",
+                                            recordid=rec,
+                                            requestor=CFG_BIBAUTHORID_AUTHOR_TICKET_ADMIN_EMAIL)
         return None
 
     if should_have_bibref and not bibref:

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -1201,9 +1201,10 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 userinfo = {'uid-ip': "userid: %s (from %s)" % (uid, req.remote_ip),
                             'name': name,
                             'email': email,
-                            'merge link': "%s/author/merge_profiles?primary_profile=%s&selection=%s" % (CFG_SITE_URL, primary_cname, selection_str)}
+                            'merge link': "%s/author/merge_profiles?primary_profile=%s&selection=%s" % (CFG_SITE_URL, primary_cname, selection_str),
+                            'uid': uid}
                 # a message is sent to the admin with info regarding the currently attempted merge
-                webapi.create_request_message(userinfo, subj='Merge profiles request')
+                webapi.create_request_message(userinfo, subj=('Merge profiles request: %s' % primary_cname))
 
                 # when redirected back to the manage profile page display a message about the merge
                 pinfo['merge_info_message'] = ("success", "confirm_operation")
@@ -1280,7 +1281,8 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                         'name_given': name_given,
                         'email_given': email_given,
                         'name_changed': name_changed,
-                        'email_changed': email_changed}
+                        'email_changed': email_changed,
+                        'uid': uid}
 
             webapi.create_request_message(userinfo)
 
@@ -2942,9 +2944,11 @@ class WebInterfaceBibAuthorIDManageProfilePages(WebInterfaceDirectory):
         else:
             return self._error_page(req, ln, "Fatal: cannot associate an author with a non valid hepname.")
 
-        webapi.connect_author_with_hepname(cname, hepname)
         webapi.session_bareinit(req)
         session = get_session(req)
+
+        webapi.connect_author_with_hepname(cname, hepname, session['uid'])
+
         pinfo = session['personinfo']
         last_visited_page = webapi.history_get_last_visited_url(pinfo['visit_diary'], just_page=True)
 
@@ -2981,7 +2985,7 @@ class WebInterfaceBibAuthorIDManageProfilePages(WebInterfaceDirectory):
         session = get_session(req)
         pinfo = session['personinfo']
         if not self._is_admin(pinfo):
-            webapi.connect_author_with_hepname(cname, hepname)
+            webapi.connect_author_with_hepname(cname, hepname, session['uid'])
         else:
             uid = getUid(req)
             add_cname_to_hepname_record(cname, hepname, uid)
@@ -3001,7 +3005,9 @@ class WebInterfaceBibAuthorIDManageProfilePages(WebInterfaceDirectory):
         else:
             return self._error_page(req, ln, "Fatal: cannot associate an author with a non valid ORCiD.")
 
-        webapi.connect_author_with_orcid(webapi.get_canonical_id_from_person_id(pid), orcid)
+        session = get_session(req)
+
+        webapi.connect_author_with_orcid(webapi.get_canonical_id_from_person_id(pid), orcid, session['uid'])
         redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, pid))
 
     def suggest_orcid_ajax(self, req, form):
@@ -3034,7 +3040,9 @@ class WebInterfaceBibAuthorIDManageProfilePages(WebInterfaceDirectory):
         if not is_valid_orcid(orcid):
             return self._fail(req, apache.HTTP_NOT_FOUND)
 
-        webapi.connect_author_with_orcid(webapi.get_canonical_id_from_person_id(pid), orcid)
+        session = get_session(req)
+
+        webapi.connect_author_with_orcid(webapi.get_canonical_id_from_person_id(pid), orcid, session['uid'])
 
     def _fail(self, req, code):
         req.status = code
@@ -3369,6 +3377,7 @@ class WebInterfaceAuthorTicketHandling(WebInterfaceDirectory):
         @return:
         @rtype: json data
         '''
+
         # Abort if the simplejson module isn't available
         assert CFG_JSON_AVAILABLE, "Json not available"
         # Fail if no json data exists in the Ajax request


### PR DESCRIPTION
- Adds cname of a profile to claim tickets.
- Adds user mail to the tickets everywhere it is possible to do so.
- Adds userid to the tickets everywhere it is possible to do so.
- Adds Hepnames ORCID automatically using bibupload.
- Adds links inside Hepnames and ORCiD record match tickets.
- Adds cname of a main profile inside merge tickets.

Signed-off-by: Mateusz Susik mateusz.susik@cern.ch
