### PR TITLE
Claim attribution fix

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -354,7 +354,7 @@ def reject_papers_from_author(pid, sigs_str, user_level=0):  # reject_papers_fro
         # it will be reassigned by tortoise) and reject it from the current person.
         current_pid, name = sig_exists[0]
         if current_pid == pid:
-            move_signature(sig, new_pid, force_claimed=True, set_unclaimed=True)
+            move_signature(sig, new_pid, force_claimed=False, set_unclaimed=True)
             pids_to_update.add(new_pid)
             add_signature((table, ref, rec), name, pid, flag=-2, user_level=user_level)
 

--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -318,12 +318,25 @@ def reject_papers_from_author(pid, sigs_str, user_level=0):  # reject_papers_fro
     @return: confirmation status and message key for each signature [(status, message_key),]
     @rtype: list [(bool, str),]
     '''
-    new_pid = get_free_author_id()
+
+    matchable_name = get_matchable_name_of_author(pid)
+    matched_authors_pids = get_authors_by_name(matchable_name,
+                                               use_matchable_name=True)
+    matched_authors_pids.remove(pid)
+
     pids_to_update = set([pid])
     statuses = list()
 
     for s in sigs_str:
         sig = _split_signature_string(s)
+
+        new_pid = None
+        for potential_pid in matched_authors_pids:
+            if not author_has_rejected_signature(potential_pid, sig):
+                new_pid = potential_pid
+                break
+        if not new_pid:
+            new_pid = get_free_author_id()
         table, ref, rec = sig
 
         # the paper should be present, either assigned or rejected
@@ -349,6 +362,24 @@ def reject_papers_from_author(pid, sigs_str, user_level=0):  # reject_papers_fro
 
     return statuses
 
+
+def author_has_rejected_signature(pid, sig):
+    """
+    Checks whether a particular author has rejected one signature.
+    @param pid: the person id of the author
+    @type pid: int
+    @param sig: the signature in question (100 / 700, bibref, bibrec)
+    @type sig: tuple of 3 elements
+    @return: A boolean indicating whether the paper has rejected a signature.
+    """
+    try:
+        return bool(run_sql("""select * from aidPERSONIDPAPERS
+                               where personid = %s and bibref_table = %s
+                               and bibref_value = %s and bibrec = %s
+                               and flag = -2""",
+                            (pid, str(sig[0]), sig[1], sig[2]))[0][0])
+    except IndexError:
+        return False
 
 def reset_papers_of_author(pid, sigs_str):  # reset_papers_flag
     '''
@@ -2966,6 +2997,16 @@ def get_names_of_author(pid, sort_by_count=True):  # get_person_db_names_count
 
     return names_count
 
+
+def get_matchable_name_of_author(pid):
+    """
+    Returns the matchable name currently associated with this person in
+    aidPERSONIDPAPERS.
+    @param pid: the person id of the author
+    @return: The matchable name of the author
+    """
+    query = 'select distinct m_name from aidPERSONIDPAPERS where personid=%s'
+    return run_sql(query, (pid,))[0][0]
 
 def merger_errors_exist():  # check_merger
     '''

--- a/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
@@ -45,8 +45,6 @@ def do_upgrade():
                                     'having count(*) > 1')
 
         if not duplicate_entries:
-            logger.log("""%s duplicate entries removed in
-                          aidPERSONIDPAPERS.""" % duplicates)
             break
 
         for entry in duplicate_entries:
@@ -65,6 +63,10 @@ def do_upgrade():
 
             duplicates += len(duplicate_entries)
 
+logger.log("""%s duplicate entries removed in
+              aidPERSONIDPAPERS.""" % duplicates)
+
 
 def estimate():
     return 1
+

--- a/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
@@ -20,7 +20,7 @@
 from invenio.dbquery import run_sql
 from invenio.bibauthorid_logutils import Logger
 
-depends_on = ['invenio_release_1_1_0']
+depends_on = ['invenio_2014_01_23_bibauthorid_rabbit_matchable_name_column']
 
 Logger.override_verbosity(True)
 

--- a/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_10_28_remove_author_duplicates.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.dbquery import run_sql
+from invenio.bibauthorid_logutils import Logger
+
+depends_on = ['invenio_release_1_1_0']
+
+Logger.override_verbosity(True)
+
+
+def info():
+    return "Remove duplicates in aidPERSONIDPAPERS."
+
+
+def do_upgrade():
+
+    logger = Logger("aidPERSONIDPAPERS_duplicates")
+
+    logger.log('Removing duplicate entries in aidPERSONIDPAPERS...')
+    duplicates = 0
+
+    while True:  # Needed because there may be >1 duplicates.
+        duplicate_entries = run_sql('select * '
+                                    'from aidPERSONIDPAPERS   '
+                                    'group by personid, bibref_table, '
+                                    'bibref_value, bibrec, flag, '
+                                    'lcul, last_updated '
+                                    'having count(*) > 1')
+
+        if not duplicate_entries:
+            logger.log("""%s duplicate entries removed in
+                          aidPERSONIDPAPERS.""" % duplicates)
+            break
+
+        for entry in duplicate_entries:
+            run_sql('delete from aidPERSONIDPAPERS '
+                    'where personid = %s and '
+                    'bibref_table = %s and '
+                    'bibref_value = %s and '
+                    'bibrec = %s and '
+                    'name = %s and '
+                    'm_name = %s and '
+                    'flag = %s and '
+                    'lcul = %s and '
+                    'last_updated = %s '
+                    'limit 1',
+                    entry)
+
+            duplicates += len(duplicate_entries)
+
+
+def estimate():
+    return 1

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -5154,4 +5154,5 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_10_new_field_add
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_11_new_field_datasource',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_07_new_journalpage_index',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_04_15_bibrec_earliest_date',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_10_28_remove_author_duplicates',NOW());
 -- end of file


### PR DESCRIPTION
This changes the behaviour when a signature is rejected.
### What is happening so far

When a signature is rejected, a new profile is created with just this signature.

So if somebody sees that there are 5 different papers for John Ellis that should not be there, they get reassigned to 5 newly created profiles.
### What this PR is changing

When a signature is rejected, it is actually reassigned to somebody with the exact matchable name who has not rejected this paper. If there is none, a new profile is created and subsequently all the signatures go there.
### Why this is a WIP

Although the implementation of this change (along with a bug fix :) ) is done, we would like your input to understand if we really really want this.

The idea has been, that a signature gets reassigned somewhere (a new profile everytime ? ) and then tortoise is supposed to fix it. However, since in reality tortoise is not running unsupervised at the moment, we just rely on the curators.

Now, each signature tries to get reassigned to an existing profile. So here is the trade-off:
- No more one-signature profiles!
- a signature may be reassigned to a an existing profile when it shouldn't be! Of course the author can say "it is not mine!"  and then it will be moved again. This can make an already self-curated profile "dirty", unless the owner provides input like it "is not mine".

Which behaviour is desirable ?

cc @glouppe 
