### PR TITLE
BibAuthorID: single profile when moving signatures

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_config.py
+++ b/modules/bibauthorid/lib/bibauthorid_config.py
@@ -254,7 +254,7 @@ PROFILE_IDENTIFIER_URL_MAPPING = {
     "orcid": "https://orcid.org/{0}"
 }
 
-NON_EMPTY_PERSON_TAGS = ['canonical_name']
+NON_EMPTY_PERSON_TAGS = ['canonical_name', 'user-created']
 
 QGRAM_LEN = 2
 MATCHING_QGRAMS_PERCENTAGE = 0.8

--- a/modules/bibauthorid/lib/bibauthorid_templates.py
+++ b/modules/bibauthorid/lib/bibauthorid_templates.py
@@ -697,7 +697,7 @@ class Template:
             'b_confirm': 'Confirm',
             'b_repeal': 'Repeal',
             'b_to_others':
-            'Assign to other person',
+            'Assign to another person',
             'b_forget': 'Forget decision'},
         buttons_verbiage_dict={
             'mass_buttons': {'no_doc_string': 'Sorry, there are currently no documents to be found in this category.',
@@ -706,7 +706,7 @@ class Template:
                              'b_repeal':
                              'Repeal',
                              'b_to_others':
-                             'Assign to other person',
+                             'Assign to another person',
                              'b_forget': 'Forget decision'},
             'record_undecided': {'alt_confirm': 'Confirm!',
                                  'confirm_text':
@@ -965,7 +965,7 @@ class Template:
                             'mass_buttons': {'no_doc_string': 'Sorry, there are currently no documents to be found in this category.',
                                              'b_confirm': 'Confirm',
                                              'b_repeal': 'Repeal',
-                                             'b_to_others': 'Assign to other person',
+                                             'b_to_others': 'Assign to another person',
                                              'b_forget': 'Forget decision'},
                         'record_undecided': {'alt_confirm': 'Confirm!',
                                              'confirm_text': 'Confirm record assignment.',
@@ -2570,7 +2570,7 @@ buttons_verbiage_dict = {
     'guest': {'mass_buttons': {'no_doc_string': 'Sorry, there are currently no documents to be found in this category.',
                                'b_confirm': 'Yes, those papers are by this person.',
                                'b_repeal': 'No, those papers are not by this person',
-                               'b_to_others': 'Assign to other person',
+                               'b_to_others': 'Assign to another person',
                                'b_forget': 'Forget decision'},
               'record_undecided': {'alt_confirm': 'Confirm!',
                                    'confirm_text': 'Yes, this paper is by this person.',
@@ -2624,7 +2624,7 @@ buttons_verbiage_dict = {
              'not_owner': {'mass_buttons': {'no_doc_string': 'Sorry, there are currently no documents to be found in this category.',
                                             'b_confirm': 'Yes, those papers are by this person.',
                                             'b_repeal': 'No, those papers are not by this person',
-                                            'b_to_others': 'Assign to other person',
+                                            'b_to_others': 'Assign to another person',
                                             'b_forget': 'Forget decision'},
                            'record_undecided': {'alt_confirm': 'Confirm!',
                                                 'confirm_text':
@@ -2655,7 +2655,7 @@ buttons_verbiage_dict = {
     'admin': {'mass_buttons': {'no_doc_string': 'Sorry, there are currently no documents to be found in this category.',
                                'b_confirm': 'Yes, those papers are by this person.',
                                'b_repeal': 'No, those papers are not by this person',
-                               'b_to_others': 'Assign to other person',
+                               'b_to_others': 'Assign to another person',
                                'b_forget': 'Forget decision'},
               'record_undecided': {'alt_confirm': 'Confirm!',
                                    'confirm_text': 'Yes, this paper is by this person.',

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -3364,8 +3364,6 @@ def connect_author_with_orcid(cname, orcid, uid):
 
 def construct_operation(operation_parts, pinfo, uid, should_have_bibref=False):
     pid = operation_parts['pid']
-    if pid == bconfig.CREATE_NEW_PERSON:
-        pid = create_new_person(uid)
     action = operation_parts['action']
     bibref, rec = split_bibrefrec(operation_parts['bibrefrec'])
     bibrefs = None

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -35,6 +35,7 @@ except ImportError:
     json = None
 
 from invenio.bibauthorid_webapi import add_cname_to_hepname_record
+from invenio.bibauthorid_webapi import create_new_person
 from invenio.config import CFG_SITE_URL, CFG_BASE_URL
 from invenio.bibauthorid_config import AID_ENABLED, PERSON_SEARCH_RESULTS_SHOW_PAPERS_PERSON_LIMIT, \
     BIBAUTHORID_UI_SKIP_ARXIV_STUB_PAGE, VALID_EXPORT_FILTERS, PERSONS_PER_PAGE, \
@@ -1101,6 +1102,8 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
             if argd['confirm']:
                 action = 'assign'
+                if pid == CREATE_NEW_PERSON:
+                    pid = create_new_person(getUid(req))
             elif argd['repeal']:
                 action = 'reject'
             elif argd['reset']:


### PR DESCRIPTION
- When a curator assigns a signature to a person
  these signatures can only be attributed to one
  pid. So far, one new pid was created per paper.

Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
