### PR TITLE
WebSearch: add middle name wild card

### DIFF
--- a/modules/websearch/lib/search_engine_query_parser.py
+++ b/modules/websearch/lib/search_engine_query_parser.py
@@ -1247,6 +1247,9 @@ class SpiresToInvenioSyntaxConverter:
             for i in range(1,len(author_name)):
                 search_pattern += ' or ' + self._EA_TAG + "\"%s, %s\"" % (author_surname, author_name[0:i])
 
+            if not author_middle_name:
+                search_pattern +=  ' or ' + self._A_TAG + '"' + author_surname + ', ' + author_name[0] + ' *"'
+
         search_pattern += ' or %s"%s, *"' % (self._A_TAG, full_search)
 
         return search_pattern

--- a/modules/websearch/lib/search_engine_query_parser_unit_tests.py
+++ b/modules/websearch/lib/search_engine_query_parser_unit_tests.py
@@ -78,8 +78,16 @@ class TestParserUtilityFunctions(InvenioTestCase):
         """Test whole convert/parse stack: SQPP.parse_query(STISC.convert_query('find a richter, burton and t quark'))"""
         self.assertEqual(self.parser.parse_query(self.converter.convert_query('find a richter, burton and t quark')),
                          ['+',
-                          'author:"richter, burton*" | exactauthor:"richter, b *" | exactauthor:"richter, b" | exactauthor:"richter, bu" | exactauthor:"richter, bur" | exactauthor:"richter, burt" | exactauthor:"richter, burto" | author:"richter, burton, *"',
+                          'author:"richter, burton*" | exactauthor:"richter, b *" | exactauthor:"richter, b" | exactauthor:"richter, bu" | exactauthor:"richter, bur" | exactauthor:"richter, burt" | exactauthor:"richter, burto" | author:"richter, b *" | author:"richter, burton, *"',
                           '+', 'title:quark'])
+
+    def test_expand_lastname_with_parse_query(self):
+        """Test one more convert/parse_query """
+        self.assertEqual(self.parser.parse_query(self.converter.convert_query("find a o'connell, heath")),
+                         ['+', 'author:"o\'connell, heath*" | exactauthor:"o\'connell, h *" | exactauthor:"o\'connell, h" | exactauthor:"o\'connell, he" | exactauthor:"o\'connell, hea" | exactauthor:"o\'connell, heat" | author:"o\'connell, h *" | author:"o\'connell, heath, *"'])
+        self.assertEqual(self.parser.parse_query(self.converter.convert_query("find a o'connell, heath b")),
+                         ['+', 'author:"o\'connell, heath* b*" | exactauthor:"o\'connell, h b" | exactauthor:"o\'connell, he b" | exactauthor:"o\'connell, hea b" | exactauthor:"o\'connell, heat b"'])
+
 
     def test_stisc_not_vs_and_not1(self):
         """Parse stack parses "find a ellis, j and not a enqvist" == "find a ellis, j not a enqvist" """
@@ -435,7 +443,7 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
 
         def test_author_full_first(self):
             """SPIRES search syntax - find a ellis, john"""
-            invenio_search = 'author:"ellis, john*" or exactauthor:"ellis, j *" or exactauthor:"ellis, j" or exactauthor:"ellis, jo" or exactauthor:"ellis, joh" or author:"ellis, john, *"'
+            invenio_search = 'author:"ellis, john*" or exactauthor:"ellis, j *" or exactauthor:"ellis, j" or exactauthor:"ellis, jo" or exactauthor:"ellis, joh" or author:"ellis, j *" or author:"ellis, john, *"'
             spires_search = 'find a ellis, john'
             self._compare_searches(invenio_search, spires_search)
 
@@ -489,7 +497,7 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
 
         def test_refersto_author_multi_name_no_quotes(self):
             """SPIRES search syntax - find a ellis and refersto author parke, sj"""
-            inv_search = 'author:ellis refersto:(author:"parke, sj*"  or exactauthor:"parke, s *"  or exactauthor:"parke, s" or author:"parke, sj, *")'
+            inv_search = 'author:ellis refersto:(author:"parke, sj*"  or exactauthor:"parke, s *"  or exactauthor:"parke, s" or author:"parke, s *" or author:"parke, sj, *")'
             spi_search = "find a ellis and refersto author parke, sj"
             self._compare_searches(inv_search, spi_search)
 


### PR DESCRIPTION
- In _create_author_search_pattern_from_fuzzy_name_dict, adds
  LastName, firstName --> LastName, f *
  (closes #1102)

Signed-off-by: Eduardo Benavidez eduardo.benavidez@gmail.com
Tested-by: Samuele Kaplun samuele.kaplun@cern.ch
