### PR TITLE
BibAuthorID: single profile when moving signatures

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_config.py
+++ b/modules/bibauthorid/lib/bibauthorid_config.py
@@ -254,7 +254,7 @@ PROFILE_IDENTIFIER_URL_MAPPING = {
     "orcid": "https://orcid.org/{0}"
 }
 
-NON_EMPTY_PERSON_TAGS = ['canonical_name']
+NON_EMPTY_PERSON_TAGS = ['canonical_name', 'user-created']
 
 QGRAM_LEN = 2
 MATCHING_QGRAMS_PERCENTAGE = 0.8

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -3363,7 +3363,9 @@ def connect_author_with_orcid(cname, orcid, uid):
 
 def construct_operation(operation_parts, pinfo, uid, should_have_bibref=False):
     pid = operation_parts['pid']
-    if pid == bconfig.CREATE_NEW_PERSON:
+    if 'pid_to_assign' in operation_parts:
+        pid = operation_parts['pid_to_assign']
+    elif pid == bconfig.CREATE_NEW_PERSON:
         pid = create_new_person(uid)
     action = operation_parts['action']
     bibref, rec = split_bibrefrec(operation_parts['bibrefrec'])

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -35,6 +35,7 @@ except ImportError:
     json = None
 
 from invenio.bibauthorid_webapi import add_cname_to_hepname_record
+from invenio.bibauthorid_webapi import create_new_person
 from invenio.config import CFG_SITE_URL, CFG_BASE_URL
 from invenio.bibauthorid_config import AID_ENABLED, PERSON_SEARCH_RESULTS_SHOW_PAPERS_PERSON_LIMIT, \
     BIBAUTHORID_UI_SKIP_ARXIV_STUB_PAGE, VALID_EXPORT_FILTERS, PERSONS_PER_PAGE, \
@@ -1098,9 +1099,12 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 # person id! (crr %s)" %repr(argd))
 
             bibrefrecs = argd['selection']
+            pid_to_assign = None
+
 
             if argd['confirm']:
                 action = 'assign'
+                pid_to_assign = create_new_person(getUid(req))
             elif argd['repeal']:
                 action = 'reject'
             elif argd['reset']:
@@ -1112,7 +1116,8 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 form['jsondata'] = json.dumps({'pid': str(pid),
                                                'action': action,
                                                'bibrefrec': bibrefrec,
-                                               'on': 'user'})
+                                               'on': 'user',
+                                               'pid_to_assign': pid_to_assign})
 
                 t = WebInterfaceAuthorTicketHandling()
                 t.add_operation(req, form)
@@ -3234,7 +3239,8 @@ class WebInterfaceAuthorTicketHandling(WebInterfaceDirectory):
         try:
             operation_parts = {'pid': int(json_data['pid']),
                                'action': json_data['action'],
-                               'bibrefrec': json_data['bibrefrec']}
+                               'bibrefrec': json_data['bibrefrec'],
+                               'pid_to_assign': json_data['pid_to_assign']}
             on_ticket = json_data['on']
         except:
             return self._fail(req, apache.HTTP_NOT_FOUND)


### PR DESCRIPTION
- Attributes signatures re-assigned by a curator
  to a single profile. So far, one new pid was
  created per paper.

Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
Reviewed-by: Samuele Kaplun samuele.kaplun@cern.ch
Reviewed-by: Gilles Louppe g.louppe@gmail.com
