### PR TITLE
BibAuthorID: ORCID support for rabbit

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -62,6 +62,7 @@ from invenio.bibauthorid_general_utils import monitored
 from invenio.bibauthorid_logutils import Logger
 import time
 from intbitset import intbitset
+import re
 
 
 # run_sql = monitored(run_sql)
@@ -4339,8 +4340,10 @@ def get_orcid_id_of_signature(sig):
     ext_ids = get_grouped_records(*ext_ids_field).values()[0]
     for ext_id in ext_ids:
         if ext_id.startswith('ORCID:'):
-            return ext_id
-
+            try:
+                return re.search(r"(\d{4}\-){3}\d{4}", ext_id).group()
+            except AttributeError:
+                pass
 
 def get_author_names_from_db(pid):  # get_person_db_names_set
     '''

--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -4322,17 +4322,24 @@ def get_inspire_id_of_signature(sig):  # get_inspire_id
 
 
 def get_orcid_id_of_signature(sig):
-    '''
-    Gets the external identifier of Inspire system for the given signature.
+    """
+    Gets the external identifier of ORCID system for the given signature.
+    The field to check is either '100__j' or '700__j'
+    and the prefix is 'ORCID:'
 
     @param sig: signature (bibref_table, bibref_value, bibrec)
     type sig: tuple (int, int, int)
 
     @return Orcid external identifier
-    @rtype: list [str]
-    '''
+    @rtype: str
+    """
+    table, ref, rec = sig
+    ext_ids_field = (str(table), ref, rec), str(table) + '__j'
 
-    return None
+    ext_ids = get_grouped_records(*ext_ids_field).values()[0]
+    for ext_id in ext_ids:
+        if ext_id.startswith('ORCID:'):
+            return ext_id
 
 
 def get_author_names_from_db(pid):  # get_person_db_names_set

--- a/modules/bibauthorid/lib/bibauthorid_testutils.py
+++ b/modules/bibauthorid/lib/bibauthorid_testutils.py
@@ -129,17 +129,24 @@ def get_modified_marc_for_test(marcxml_string, author_name=None,
     return tostring(marcxml)
 
 
-def build_test_marcxml_field(record, tag, content, is_controlfield=False):
+def build_test_marcxml_field(record, tag, content, is_controlfield=False,
+                             code='a'):
     if is_controlfield:
         marc_field = SubElement(record, 'controlfield',
                                 {'tag': str(tag)})
         marc_field.text = content
     else:
-        marc_field = SubElement(record, 'datafield',
-                                {'tag': str(tag),
-                                    'ind1': '', 'ind2': ''})
-        marc_sub = SubElement(marc_field, 'subfield', {'code': 'a'})
-        marc_sub.text = content
+        if code != 'a':
+            for sub in record.getchildren():
+                if sub.attrib['tag'] == '100':
+                    ext_id_sub = SubElement(sub, 'subfield', {'code': code})
+                    ext_id_sub.text = content
+        else:
+            marc_field = SubElement(record, 'datafield',
+                                    {'tag': str(tag),
+                                     'ind1': '', 'ind2': ''})
+            marc_sub = SubElement(marc_field, 'subfield', {'code': code})
+            marc_sub.text = content
 
 
 def get_new_marc_for_test(name, author_name=None, co_authors_names=None,
@@ -155,6 +162,8 @@ def get_new_marc_for_test(name, author_name=None, co_authors_names=None,
     if co_authors_names:
         for co_author_name in co_authors_names:
             build_test_marcxml_field(record, 700, co_author_name)
+    if ext_id:
+        build_test_marcxml_field(record, 100, ext_id, code='j')
 
     return tostring(record)
 


### PR DESCRIPTION
- Rabbit tries to match papers to profiles
  by ORCID, after trying to do so with an
  INSPIRE id.
- The ORCID is located in $__j fields with
  the prefix of 'ORCID:'.

Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
