### PR TITLE
BibSearch: fix keyerror for hidden tags

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -5069,7 +5069,7 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
             record = get_record(recID)
             if not can_see_hidden:
                 for tag in CFG_BIBFORMAT_HIDDEN_TAGS:
-                    del record[tag]
+                    record.pop(tag, None)
                 ot = list(set(ot) - set(CFG_BIBFORMAT_HIDDEN_TAGS))
             out += record_xml_output(record, ot)
         else:


### PR DESCRIPTION
one-liner fixing
- 2014-11-21 15:07:50 -> KeyError: '595' (search_engine.py:5072:print_record)

from searches like 
/search?cc=HepNames&p=100__z%3Acurrent&ot=100&of=xm&rg=250
