### PR TITLE
BibauthorID: error message when merging of profiles fails

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid.js
+++ b/modules/bibauthorid/lib/bibauthorid.js
@@ -2448,8 +2448,16 @@ $(document).ready(function() {
                                     $modal.find(".modal-footer>a.back").removeClass("disabled").text("Close");
                                     $form.data({"mergeConfirmed": true});
                                 },
-                                error: function (jqXHR, status, data) {
-                                    $modal.modal("hide");
+                                error: function (data, status, jqXHR) {
+                                    if (data.status == 409) {
+                                        $modal.find(".modal-header>.modal-title").text("Conflict");
+                                        $modal.find(".modal-body").html("<p>" + data.responseText + "</p>");
+                                        $modal.find(".modal-footer>a.confirm").remove();
+                                        $modal.find(".modal-footer>a.back").removeClass("disabled").text("Close");
+                                    }
+                                    else {
+                                        $modal.modal("hide");
+                                    }
                                 }
                             });
                         });

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -1182,22 +1182,19 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 is_admin = True
 
             # checking if there are restrictions regarding this merge
-            can_perform_merge, preventing_pid = webapi.merge_is_allowed(primary_pid, pids_to_merge, is_admin)
+            can_perform_merge, preventing_pid, error_message = webapi.merge_is_allowed(primary_pid, pids_to_merge, is_admin)
 
             if not can_perform_merge:
                 # when redirected back to the merge profiles page display an error message
                 # about the currently attempted merge
-                pinfo['merge_info_message'] = ("failure", "confirm_failure")
                 session.dirty = True
-
-                redirect_url = "%s/author/merge_profiles?primary_profile=%s" % (CFG_SITE_URL, primary_cname)
-                return redirect_to_url(req, redirect_url)
+                req.status = apache.HTTP_CONFLICT
+                c_name = webapi.get_canonical_id_from_person_id(preventing_pid)
+                return 'Cannot merge profile: %s Reason: %s' % (c_name,
+                                                                error_message)
 
             if is_admin:
                 webapi.merge_profiles(primary_pid, pids_to_merge)
-                # when redirected back to the manage profile page display a message about the currently attempted merge
-                pinfo['merge_info_message'] = ("success", "confirm_success")
-
             else:
                 name = ''
                 if 'user_last_name' in pinfo:


### PR DESCRIPTION
- A message is shown when trying to merge an author profile to a
  coauthor. This merging should not be possible.

Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
