### PR TITLE
general: support for arXiv 5-digits IDs

### DIFF
--- a/modules/bibformat/lib/elements/bfe_sciencewise.py
+++ b/modules/bibformat/lib/elements/bfe_sciencewise.py
@@ -28,7 +28,7 @@ import re
 from invenio.config import CFG_BASE_URL, CFG_SITE_LANG, CFG_CERN_SITE
 from invenio.messages import gettext_set_language
 
-_RE_MODERN_ARXIV = re.compile('(arxiv:)?(?P<number>\d{4}.\d{4}(v\d+)?)')
+_RE_MODERN_ARXIV = re.compile('(arxiv:)?(?P<number>\d{4}.\d{4,5}(v\d+)?)')
 _RE_OLD_ARXIV = re.compile('(arxiv:)?(?P<number>\w+-\w+/\d{7}(v\d+)?)')
 _RE_BAD_OLD_ARXIV = re.compile('(arxiv:)?(?P<archive>\w+-\w+)-(?P<number>\d{7}(v\d+)?)')
 

--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -752,7 +752,7 @@ def standardize_report_number(report_number):
     Currently we:
     * remove category for arxiv papers
     """
-    report_number = re.sub(ur'(?:arXiv:)?(\d{4}\.\d{4}) \[[a-zA-Z\.-]+\]',
+    report_number = re.sub(ur'(?:arXiv:)?(\d{4}\.\d{4,5}) \[[a-zA-Z\.-]+\]',
                   ur'arXiv:\g<1>',
                   report_number,
                   re.I | re.U)

--- a/modules/miscutil/lib/plotextractor_getter.py
+++ b/modules/miscutil/lib/plotextractor_getter.py
@@ -498,7 +498,7 @@ def src_pdf_from_marc(marc_file):
     marc_text = marc_file.read()
     marc_file.close()
 
-    arXiv_match = '(([a-zA-Z\\-]+/\\d{7})|(\\d{4}\\.\\d{4}))'
+    arXiv_match = '(([a-zA-Z\\-]+/\\d{7})|(\\d{4}\\.\\d{4,5}))'
     DESY_match = 'DESY-\\d{2,4}-\\d{3}'
 
     pdf_loc = None


### PR DESCRIPTION
- Amends the several regular expressions spread around the code that
  deal with arXiv identifiers so that the upcoming 5-digits based
  identifiers are also supported.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
