### PR TITLE
WebSearch: selfcites in SPIRES syntax

### DIFF
--- a/modules/websearch/lib/search_engine_query_parser.py
+++ b/modules/websearch/lib/search_engine_query_parser.py
@@ -605,6 +605,21 @@ class SpiresToInvenioSyntaxConverter:
         'rank' : 'rank:',
         'cat' : 'cataloguer:',
 
+        # selfcites
+        'citedexcludingselfcites': 'citedexcludingselfcites:',
+        'cited.excluding.selfcites': 'citedexcludingselfcites:',
+        'cited.nosc': 'citedexcludingselfcites:',
+        'citedx': 'citedexcludingselfcites:',
+        'cx': 'citedexcludingselfcites:',
+        'citedbyexcludingselfcites': 'citedbyexcludingselfcites:',
+        'citedby.excluding.selfcites': 'citedbyexcludingselfcites:',
+        'citedby.nosc': 'citedbyexcludingselfcites:',
+        'citedbyx': 'citedbyexcludingselfcites:',
+        'referstoexcludingselfcites': 'referstoexcludingselfcites:',
+        'refersto.excluding.selfcites': 'referstoexcludingselfcites:',
+        'refersto.nosc': 'referstoexcludingselfcites:',
+        'referstox': 'referstoexcludingselfcites:',
+
         # replace all the keywords without match with empty string
         # this will remove the noise from the unknown keywrds in the search
         # and will in all fields for the words following the keywords


### PR DESCRIPTION
- Introduces support for selfcites family of operators in the special
  SPIRES syntax.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
