### PR TITLE
BibAuthorID: putting ORCIDpush on back

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_templates.py
+++ b/modules/bibauthorid/lib/bibauthorid_templates.py
@@ -2128,17 +2128,16 @@ It holds a record of all your research activities. You can add your ORCID to all
         modal = ""
 
         if orcid_data['orcids']:
-            html_orcid += '<div class="alert alert-danger" role="alert">Due to technical problems beyond our control, the ORCID synchronisation' \
-                          ' is unavailable. The ORCID team is already working on a solution.<br/></br>We' \
-                          ' apologise for any inconveniences this may cause.</div>'
             html_orcid += _(
                 'This profile is already connected to the following ORCID: <strong>%s</strong></br><br>' %
                 (",".join(['<a rel="nofollow" href="http://www.orcid.org/' + orcidid + '"">' + orcidid + '</a>' for orcidid in orcid_data['orcids']]),))
             if orcid_data['push']:
                 html_orcid += '<div class="btn-group" role="group">'
-                html_orcid += '<button class="btn btn-disabled">%s</button> ' % (
+                html_orcid += '<button class="btn btn-default" data-toggle="modal" data-target="#orcidPushHelp">%s</button> ' % (
                     _("Export your publications to ORCID"))
-                html_orcid += '<button id="orcidHelp" class="btn btn-disabeld"><span class="glyphicon glyphicon-question-sign"></span>&nbsp'
+                html_orcid += '<button id="orcidHelp" class="btn btn-primary" data-toggle="popover" data-placement="bottom" \
+                    data-content="%s"><span class="glyphicon glyphicon-question-sign"></span>&nbsp' % \
+                    _("Please note that only the publications that are verified as yours on INSPIRE will be exported to ORCID.")
                 html_orcid += '</button></div>'
             else:
                 html_orcid += 'Your works will be pushed automatically.<br><br>'

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -2922,7 +2922,7 @@ class WebInterfaceBibAuthorIDManageProfilePages(WebInterfaceDirectory):
             # Authenticate
             session['pushorcid'] = True
             session.dirty = True
-            redirect_to_url(req, "%s/youraccount/oauth2?provider=%s&scope=/orcid-works/create" % (CFG_SITE_SECURE_URL, 'orcid'))
+            redirect_to_url(req, "%s/youraccount/oauth2?provider=%s&scope=/orcid-works/update+/orcid-works/create" % (CFG_SITE_SECURE_URL, 'orcid'))
 
         # We expect user to have only one ORCID
         assert(len(webapi.get_orcids_by_pid(session['orcid_pid'])) == 1)


### PR DESCRIPTION
- Reverts blocking of the ORCIDpush.
- Adds another scope to the tokens.
- Doesn't send coauthors if their number is greater
  than a defined constant.

Signed-off-by: Mateusz Susik mateusz.susik@cern.ch
