### PR TITLE
BibCatalog: REST-based RT reimplementation

### DIFF
--- a/modules/bibcatalog/lib/bibcatalog_system_rt_unit_tests.py
+++ b/modules/bibcatalog/lib/bibcatalog_system_rt_unit_tests.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2012, 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 ##
-## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 
 """Unit tests for bibcatalog_system_rt library."""
@@ -23,10 +23,11 @@
 from invenio.testutils import InvenioTestCase
 from invenio.testutils import make_test_suite, run_test_suite
 
-from invenio import bibcatalog_system_rt 
+from invenio import bibcatalog_system_rt
 
 
 class BibCatalogSystemRTTest(InvenioTestCase):
+
     """Testing of BibCatalog."""
 
     def setUp(self):
@@ -37,24 +38,6 @@ class BibCatalogSystemRTTest(InvenioTestCase):
 
     def tearDown(self):
         pass
-
-    def test_rt_run_command_fails_with_bum_environment(self):
-        """bibcatalog_system_rt - _run_rt_command gives None for bad environment"""
-        # A special kind of test requires a very weird environment
-        bibcatalog_system_rt.CFG_BIBCATALOG_SYSTEM_RT_URL = None
-        testobj = bibcatalog_system_rt.BibCatalogSystemRT()
-        stdout = testobj._run_rt_command('/bin/ls /')
-        bibcatalog_system_rt.CFG_BIBCATALOG_SYSTEM_RT_URL = 'http://testingdomainbadbad.invenio-software.org'
-        self.assertEquals(stdout, None)
-
-    def test_rt_run_command(self):
-        """bibcatalog_system_rt - running simple command."""
-        stdout = self.rt._run_rt_command('/bin/ls /')
-        self.assertTrue(len(stdout) > 0)
-
-    def test_rt_run_command_exception_bad_cmd(self):
-        """bibcatalog_system_rt - bad command execution raises exception"""
-        self.assertRaises(ValueError, self.rt._run_rt_command, '/etc/hosts')
 
 
 TEST_SUITE = make_test_suite(BibCatalogSystemRTTest)

--- a/modules/bibedit/lib/bibedit_engine.py
+++ b/modules/bibedit/lib/bibedit_engine.py
@@ -1321,8 +1321,10 @@ def perform_request_bibcatalog(request_type, uid, data):
         elif uid:
             bibcat_resp = BIBCATALOG_SYSTEM.check_system(uid)
             if bibcat_resp == "":
-                tickets_found = BIBCATALOG_SYSTEM.ticket_search(uid,
-                    status=['new', 'open'], recordid=data['recID'])
+                tickets_found = set(
+                    BIBCATALOG_SYSTEM.ticket_search(uid, status='new', recordid=data['recID'])) | set(
+                    BIBCATALOG_SYSTEM.ticket_search(uid, status='open', recordid=data['recID']))
+
                 tickets = []
                 for t_id in tickets_found:
                     ticket_info = BIBCATALOG_SYSTEM.ticket_get_info(

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ Cerberus==0.5
 HTMLParser==0.0.2
 h5py==2.3.1
 unittest2==0.5.1
+rt==1.0.8


### PR DESCRIPTION
- Reimplements bibcatalog_system_rt module to use the rt python
  RT REST-based wrapper instead of using the RT Perl CLI tool.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
