### PR TITLE
BibUpload: faster recjson deletion after updates

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+## Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -1903,7 +1903,7 @@ CFG_BIBUPLOAD_SERIALIZE_RECORD_STRUCTURE = 1
 ## generate them on-the-fly.  Useful to always present latest data of
 ## records upon record display, until the periodical bibreformat job
 ## runs next and updates the cache.
-CFG_BIBUPLOAD_DELETE_FORMATS = hb
+CFG_BIBUPLOAD_DELETE_FORMATS = hb,recjson
 
 ## CFG_BIBUPLOAD_DISABLE_RECORD_REVISIONS -- set to 1 if keeping
 ## history of record revisions is not necessary (e.g. because records


### PR DESCRIPTION
- Deletes cached `recjson` format immediately after record update, so
  that it is not necessary to wait for the next `bibreformat` run for
  the record JSON format and the record master format (MARC) to be
  fully consistent.  (addresses #1708)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
