### PR TITLE
WebSearch: fix external search for cc=''

### DIFF
--- a/modules/websearch/lib/websearch_external_collections.py
+++ b/modules/websearch/lib/websearch_external_collections.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -185,6 +185,9 @@ def select_external_engines(collection_name, selected_external_searches):
 # Search
 def do_external_search(req, lang, vprint, basic_search_units, search_engines, print_search_info=True, print_body=True):
     """Make the external search."""
+    if not search_engines:
+        return
+
     _ = gettext_set_language(lang)
     vprint(3, 'beginning external search')
     engines_list = []


### PR DESCRIPTION
- avoids errors in determining list of external search engines
  when the collection is not specified

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com

Currently Inspire generates exceptions for searches with empty url parameter cc=
from websearch_external_collections which attempts to compose a list of external search engines based on collection name. 

see e.g.
http://inspirehep.net/search?cc=&p=%22ion%2Binjection%2Bin%2Ba%2Bcyclotron%22

and

https://rt.inspirehep.net/Ticket/Display.html?id=481298

This exception has already been seen 2498 times
    last time it was seen: 2015-04-16 18:24:32
    last time it was notified: 2015-04-16 15:56:03

There are a few thousand of these, almost all generated from
  referer: http://library.web.cern.ch/

websearch_external_collections.select_external_engines() returns (None, None) for unknown collections, but websearch_external_collections.do_external_search() expects an iterable.
I decided to test for None in the latter instead of returning empty sets in the former, because it might be useful in other circumstances.
