### PR TITLE
Bibauthorid: fix urllib.quote use on int

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -865,7 +865,8 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 pinfo['should_check_to_autoclaim'] = True
                 pinfo["login_info_message"] = "confirm_success"
                 session.dirty = True
-                redirect_to_url(req, '%s/author/manage_profile/%s' % (CFG_SITE_URL, urllib.quote(redirect_pid)))
+                redirect_to_url(req, '%s/author/manage_profile/%s'
+                                % (CFG_SITE_URL, urllib.quote(str(redirect_pid))))
             # if someone have already claimed this profile it redirects to choose_profile with an error message
             else:
                 param = ''


### PR DESCRIPTION
urllib.quote() throws exceptions when applied to an int
redirect_pid should be an int, but if it is not for some reason ensure safe quoting

thus changing urllib.quote(redirect_pid)  to urllib.quote(str(redirect_pid))
