### PR TITLE
BibFormat: look for editors also in 700__e

### DIFF
--- a/modules/bibformat/lib/elements/bfe_editors.py
+++ b/modules/bibformat/lib/elements/bfe_editors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -16,33 +16,38 @@
 ## You should have received a copy of the GNU General Public License
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""BibFormat element - Prints editors
 """
-__revision__ = "$Id$"
+BibFormat element - Prints editors
 
-def format_element(bfo, limit, separator=' ; ', extension='[...]', print_links="yes"):
+"""
+
+
+def format_element(bfo, limit, separator=' ; ',
+                   extension='[...]', print_links="yes"):
     """
     Prints the list of editors of a record.
 
     @param limit: the maximum number of editors to display
     @param separator: the separator between editors.
     @param extension: a text printed if more editors than 'limit' exist
-    @param print_links: if yes, print the editors as HTML link to their publications
+    @param print_links: if yes, print the editors as HTML link
+           to their publications
     """
     from urllib import quote
     from invenio.config import CFG_BASE_URL
-    from invenio import bibrecord
+    from invenio.bibrecord import field_get_subfield_values, \
+        record_get_field_instances
 
-    authors = bibrecord.record_get_field_instances(bfo.get_record(), '100')
-
-    editors = [bibrecord.field_get_subfield_values(author, 'a')[0]
-               for author in authors if len(bibrecord.field_get_subfield_values(author, "e")) > 0 and bibrecord.field_get_subfield_values(author, "e")[0]=="ed." ]
+    authors = record_get_field_instances(bfo.get_record(), '100') + \
+        record_get_field_instances(bfo.get_record(), '700')
+    editors = [field_get_subfield_values(author, 'a')[0]
+               for author in authors
+               if len(field_get_subfield_values(author, "e")) > 0
+               and field_get_subfield_values(author, "e")[0] == "ed."]
 
     if print_links.lower() == "yes":
-        editors = ['<a href="' + CFG_BASE_URL + '/search?f=author&p=' + \
-                   quote(editor) + \
-                   '&amp;ln='+ bfo.lang + \
-                   '">' + editor + '</a>'
+        editors = ['<a href="%s/search?f=author&amp;p=%s&amp;ln=%s">%s</a>'
+                   % (CFG_BASE_URL, quote(editor), bfo.lang, editor)
                    for editor in editors]
 
     if limit.isdigit() and len(editors) > int(limit):


### PR DESCRIPTION
so far bfe_editors only looks in author MARC subfield 100__e for 'ed.' to indicate this is an editor
this patch extends that to also look in MARC subfield 700__e, which in Inspire's metadata also might contain editor indicator

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
