### PR TITLE
OPS BibUpload: duplicate records in Asana

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -53,6 +53,14 @@ re_CFG_JOURNAL_PUBINFO_STANDARD_FORM_REGEXP_CHECK \
                    = re.compile(CFG_JOURNAL_PUBINFO_STANDARD_FORM_REGEXP_CHECK)
 
 
+_RECORDS_WITH_ERRATUM = None
+def get_records_wit_erratum():
+    global _RECORDS_WITH_ERRATUM
+    if _RECORDS_WITH_ERRATUM is None:
+        from invenio.search_engine import search_pattern
+        _RECORDS_WITH_ERRATUM = search_pattern(p='**', f='773__m')
+    return _RECORDS_WITH_ERRATUM
+
 def record_duplicates_in_asana(match, recids):
     if not CFG_INSPIRE_SITE:
         return
@@ -67,7 +75,11 @@ def record_duplicates_in_asana(match, recids):
     if len(recids) == 2:
         notes += "\nhttps://inspirehep.net/record/merge/#recid1=%s&recid2=%s" % (recids[1], recids[0])
 
-    ticket = api.create_task(name='%s refers to record IDs %s' % (match, ', '.join(str(recid) for recid in recids)),
+    prefix = ""
+    if recids & get_records_wit_erratum():
+        prefix = "[ERRATUM?] "
+
+    ticket = api.create_task(name='%s%s refers to record IDs %s' % (prefix, match, ', '.join(str(recid) for recid in recids)),
                              workspace=CFG_INSPIRE_ASANA_WORKSPACE, notes=notes,
                              projects=[CFG_INSPIRE_ASANA_DUPLICATE_RECIDS_PROJECT])
 

--- a/modules/bibupload/lib/bibupload.py
+++ b/modules/bibupload/lib/bibupload.py
@@ -1158,7 +1158,7 @@ def retrieve_rec_id(record, opt_mode, pretend=False, post_phase=False):
     if rec_id is None:
         # 5th step we look for the DOI.
         record_dois = record_extract_dois(record)
-        matching_recids = set()
+        matching_recids = intbitset()
         if record_dois:
             # try to find the corresponding rec id from the database
             for record_doi in record_dois:
@@ -1172,6 +1172,8 @@ def retrieve_rec_id(record, opt_mode, pretend=False, post_phase=False):
                           " database %s that match the DOI(s) in the input"
                           " MARCXML %s" % (repr(matching_recids), repr(record_dois)),
                           verbose=1, stream=sys.stderr)
+                from invenio.bibrank_citation_indexer import record_duplicates_in_asana
+                record_duplicates_in_asana(record_doi, matching_recids)
                 return -1
             elif len(matching_recids) == 1:
                 rec_id = matching_recids.pop()
@@ -1220,7 +1222,7 @@ def check_record_doi_is_unique(rec_id, record):
     """
     record_dois = record_extract_dois(record)
     if record_dois:
-        matching_recids = set()
+        matching_recids = intbitset()
         for record_doi in record_dois:
             possible_recid = find_record_from_doi(record_doi)
             if possible_recid:
@@ -1230,6 +1232,8 @@ def check_record_doi_is_unique(rec_id, record):
             msg = "   Failed: Multiple records found in the" \
                       " database %s that match the DOI(s) in the input" \
                       " MARCXML %s" % (repr(matching_recids), repr(record_dois))
+            from invenio.bibrank_citation_indexer import record_duplicates_in_asana
+            record_duplicates_in_asana(", ".join(record_dois), matching_recids)
             return (False, msg)
         elif len(matching_recids) == 1:
             matching_recid = matching_recids.pop()
@@ -1238,6 +1242,8 @@ def check_record_doi_is_unique(rec_id, record):
                 msg = "   Failed: DOI(s) %s found in this record (#%s)" \
                       " already exist(s) in another other record (#%s)" % \
                       (repr(record_dois), rec_id, matching_recid)
+                from invenio.bibrank_citation_indexer import record_duplicates_in_asana
+                record_duplicates_in_asana(", ".join(record_dois), matching_recids)
                 return (False, msg)
     return (True, "")
 


### PR DESCRIPTION
- When BibUpload spots that two records are duplicates
  (e.g. because a DOI is being added to record 1 while
  it was already existing for record 2) creates a ticket
  in Asana with sensible links and prefixing the title
  of the link in case any of the involved records has
  in a way or another a 773__m field for Erratum

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
