### PR TITLE
BibRank: better standardize_report_number

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -791,7 +791,7 @@ def standardize_report_number(report_number):
     Currently we:
     * remove category for arxiv papers
     """
-    report_number = re.sub(ur'(?:arXiv:)?(\d{4}\.\d{4,5}) \[[a-zA-Z\.-]+\]',
+    report_number = re.sub(ur'(?:arXiv:)?((\d{4}\.\d{4,5})|(\w+-\w+/\d+))(v\d+)?( \[[a-zA-Z\.-]+\])?',
                   ur'arXiv:\g<1>',
                   report_number,
                   re.I | re.U)


### PR DESCRIPTION
- Improves standardize_report_number() to normalize arXiv report
  number also taking into consideration versioning and old arXiv
  formats.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
