### PR TITLE
WebAuthorList: SPIRES/INSPIRE and better import

### DIFF
--- a/modules/webauthorlist/lib/authorlist.js
+++ b/modules/webauthorlist/lib/authorlist.js
@@ -39,8 +39,8 @@ Array.prototype.remove = function( value ) {
 
 /*
 * Variable: Authorlist.CSS
-* Purpose:  Central enumeration and mapping for the CSS classes used in the 
-*           Authorlist prototype. Eases consistent look up and renaming if 
+* Purpose:  Central enumeration and mapping for the CSS classes used in the
+*           Authorlist prototype. Eases consistent look up and renaming if
 *           required.
 *
 */
@@ -49,7 +49,7 @@ Authorlist.CSS = {
     'Active'            : 'ui-state-active',
     'Loading'           : 'AuthorlistLoading',
     'Progress'          : 'AuthorlistProgress',
-    
+
 
     // Section classes
     'Affiliations'      : 'AuthorlistAffiliations',
@@ -62,11 +62,11 @@ Authorlist.CSS = {
     'Menu'              : 'AuthorlistMenu',
     'Paper'             : 'AuthorlistPaper',
     'Reference'         : 'AuthorlistReference',
-    
+
     // Input classes
     'Input'             : 'AuthorlistInput',
     'Label'             : 'AuthorlistLabel',
-    
+
     // Button classes
     'Add'               : 'AuthorlistAdd',
     'AddIcon'           : 'ui-icon-plusthick',
@@ -88,7 +88,7 @@ Authorlist.CSS = {
     'RemoveIcon'        : 'ui-icon-minusthick',
     'Save'              : 'AuthorlistSave',
     'SaveIcon'          : 'ui-icon-disk',
-    
+
     // Dialog classes
     'Bullet'            : 'AuthorlistBullet',
     'BulletIcon'        : 'ui-icon-carat-1-e',
@@ -115,7 +115,7 @@ Authorlist.DEFAULT_ERROR = [ 'Site is currently not reachable',
 
 /*
 * Variable: Authorlist.EMPTY
-* Purpose:  RegEx that defines that a field is considered to be empty if it 
+* Purpose:  RegEx that defines that a field is considered to be empty if it
 *           contains only whitespaces or no characters at all.
 *
 */
@@ -130,7 +130,7 @@ Authorlist.ID = /id=([^&$]+)/;
 
 /*
 * Variable: Authorlist.Indices
-* Purpose:  Names for the indices into the result arrays of the authors and 
+* Purpose:  Names for the indices into the result arrays of the authors and
 *           affiliations .fnGetData() arrays
 *
 */
@@ -146,7 +146,7 @@ Authorlist.INDICES = {
 
 /*
 * Variable: Authorlist.URLS
-* Purpose:  Sets up a mapping of commonly used URLS for the save and export 
+* Purpose:  Sets up a mapping of commonly used URLS for the save and export
 *           functionality.
 *
 */
@@ -192,7 +192,7 @@ function Authorlist( sId ) {
 
 /*
 * Function: fnGetData
-* Purpose:  Returns the whole content of the authorlist tool as an objects. It 
+* Purpose:  Returns the whole content of the authorlist tool as an objects. It
 *           includes the values of the paper information, the author SpreadSheet
 *           as well as the ones of the affiliations sheet.
 * Input(s): void
@@ -223,11 +223,11 @@ Authorlist.prototype.fnLoadData = function( oData ) {
 
 /*
 * Function: fnValidate
-* Purpose:  Returns a list of errors if the entered data in the author list 
-*           fields are in valid. This means it checks whether all required 
+* Purpose:  Returns a list of errors if the entered data in the author list
+*           fields are in valid. This means it checks whether all required
 *           fields are set as well as whether every link string is correct. If
 *           so the array with error message is empty.
-* Input(s): object:oData - the data of the authorlist as it can be obtained by 
+* Input(s): object:oData - the data of the authorlist as it can be obtained by
                            the fnGetData() call
 * Returns:  array string:asErrors - true if data is sane, else false
 *
@@ -256,7 +256,7 @@ Authorlist.prototype.fnValidate = function( oData ) {
 
 /*
 * Function: _fnBackToMainPage
-* Purpose:  Invoking this function sends the user immediately back to the main 
+* Purpose:  Invoking this function sends the user immediately back to the main
 *           page. All unchanged state is lost.
 * Input(s): void
 * Returns:  void
@@ -317,8 +317,8 @@ Authorlist.prototype._fnConfirm = function( fnCallback, sMessage ) {
 
 /*
 * Function: _fnCreateAffiliations
-* Purpose:  Creates all DOM-elements required for the affiliations - i.e. the 
-*           headline and the wrapping div - embeds a SpreadSheet instance in it 
+* Purpose:  Creates all DOM-elements required for the affiliations - i.e. the
+*           headline and the wrapping div - embeds a SpreadSheet instance in it
 *           and returns the created object afterwards.
 * Input(s): node:nParent - the node where the affiliations will be embedded
 * Returns:  object:oAffiliations - the SpreadSheet instance
@@ -365,8 +365,8 @@ Authorlist.prototype._fnCreateAffiliations = function( nParent ) {
 
 /*
 * Function: _fnCreateAuthors
-* Purpose:  Creates all DOM-elements required for the authors - i.e. the 
-*           headline and the wrapping div - embeds a SpreadSheet instance in it 
+* Purpose:  Creates all DOM-elements required for the authors - i.e. the
+*           headline and the wrapping div - embeds a SpreadSheet instance in it
 *           and returns the created object afterwards.
 * Input(s): node:nParent - the node where the authors will be embedded
 * Returns:  object:oAffiliations - the SpreadSheet instance
@@ -419,8 +419,8 @@ Authorlist.prototype._fnCreateAuthors = function( nParent ) {
 
 /*
 * Function: _fnCreateButton
-* Purpose:  Creates a button in the given parent element with the given label 
-*           and - if set - given icon and returns the new button. The button is 
+* Purpose:  Creates a button in the given parent element with the given label
+*           and - if set - given icon and returns the new button. The button is
 *           a jQuery UI button widget.
 * Input(s): node:nParent - the parent element
 *           string:sLabel - the button label
@@ -506,7 +506,7 @@ Authorlist.prototype._fnCreateHeadline = function( nParent, sTitle ) {
 
 /*
 * Function: _fnCreateMenu
-* Purpose:  Creates a new headline for the menu, creates the buttons and embeds 
+* Purpose:  Creates a new headline for the menu, creates the buttons and embeds
 *           it into the parent and returns the created node.
 * Input(s): node:nParent - where to append the paper information to
 * Returns:  node:nMenu - the menu node
@@ -533,7 +533,7 @@ Authorlist.prototype._fnCreateMenu = function( nParent ) {
     var nImport = this._fnCreateButton( nMenu, 'Import', Authorlist.CSS.ImportIcon );
     var nImportXML = this._fnCreateButton( nMenu, 'ImportXML', Authorlist.CSS.ImportIcon );
 
-    // Add classes   
+    // Add classes
     nBackButton.addClass( Authorlist.CSS.Back );
     nSave.addClass( Authorlist.CSS.Save );
     nDeleteButton.addClass( Authorlist.CSS.Delete );
@@ -573,7 +573,7 @@ Authorlist.prototype._fnCreateMenu = function( nParent ) {
 
 /*
 * Function: _fnCreatePaper
-* Purpose:  Creates a new headline for the paper information, creates a Paper 
+* Purpose:  Creates a new headline for the paper information, creates a Paper
 *           objects, embeds it into the parent and returns it.
 * Input(s): node:nParent - where to append the paper information to
 * Returns:  object:oPaper - the Paper instance.
@@ -591,7 +591,7 @@ Authorlist.prototype._fnCreatePaper = function( nParent ) {
 /*
 * Function: _fnDelete
 * Purpose:  Deletes the currently open sheet completely from the database. There
-*           is no backup copy or safety net. Sends the user on success back to 
+*           is no backup copy or safety net. Sends the user on success back to
 *           the main page or shows an error on failure.
 * Input(s): void
 * Returns:  void.
@@ -812,7 +812,7 @@ Authorlist.prototype._fnImportXMLDialog = function(nDialog, nOptions) {
                 if (jQuery.isEmptyObject(oData) || typeof oData.authors === 'undefined') {
                     var warning = 'There was no data to import from this file. \
                     Please make sure the file meets the requirements of the \
-                    specification: http://www.slac.stanford.edu/spires/hepnames/authors_xml';
+                    specification: http://inspirehep.net/info/HepNames/tools/authors_xml/index';
                     self._fnShowErrors(warning, []);
                     return;
                 }
@@ -880,7 +880,7 @@ Authorlist.prototype._fnCleanEmptyAffiliations= function( oData ) {
 
 /*
 * Function: _fnExport
-* Purpose:  Exports the data of the authorlist instance on the server as long as 
+* Purpose:  Exports the data of the authorlist instance on the server as long as
 *           there are no errors, which will be displayed in a dialog otherwise.
 * Input(s): node:nButton - the pressed export button
 * Returns:  void
@@ -945,8 +945,8 @@ Authorlist.prototype._fnProgress = function() {
 
 /*
 * Function: _fnProgressDone
-* Purpose:  Remove the progressing cursor from the body and the loading bar on 
-*           the upper 
+* Purpose:  Remove the progressing cursor from the body and the loading bar on
+*           the upper
 * Input(s): string:sId - the paper id to be loaded
 * Returns:  void
 *
@@ -960,8 +960,8 @@ Authorlist.prototype._fnProgressDone = function() {
 
 /*
 * Function: _fnRetrieve
-* Purpose:  Retrieves the data of the given paper id from the server an sets 
-*           them on success as the preset values of the table or shows an error 
+* Purpose:  Retrieves the data of the given paper id from the server an sets
+*           them on success as the preset values of the table or shows an error
 *           if a failure occures.
 * Input(s): string:sId - the paper id to be loaded
 * Returns:  void
@@ -989,7 +989,7 @@ Authorlist.prototype._fnRetrieve = function( sId ) {
 
 /*
 * Function: _fnSave
-* Purpose:  Saves the data of the authorlist instance on the server as long as 
+* Purpose:  Saves the data of the authorlist instance on the server as long as
 *           there are no errors, which will be displayed in a dialog otherwise.
 * Input(s): void
 * Returns:  void
@@ -1098,14 +1098,14 @@ Authorlist.prototype._fnShowErrors = function( sPreamble, asErrors, fnCallback) 
 
 /*
 * Function: _fnValidateAffiliations
-* Purpose:  Validates a subset - namely the affiliations - of the whole data of 
-*           the fnGetData() call in fnValidate. It makes sure that all acronyms 
-*           and names/addresses of an affiliation is set. At the same time it 
-*           generates errors messages if this is not the case and appends them 
+* Purpose:  Validates a subset - namely the affiliations - of the whole data of
+*           the fnGetData() call in fnValidate. It makes sure that all acronyms
+*           and names/addresses of an affiliation is set. At the same time it
+*           generates errors messages if this is not the case and appends them
 *           to the passed error messages array.
 * Input(s): array array object:aaoAffiliations - the affiliations data entry
 *           array string:asErrors - the error messages array
-* Returns:  array string:asAcronyms - an array containing the valid affiliation 
+* Returns:  array string:asAcronyms - an array containing the valid affiliation
                                       acronyms; used in _fnValidateAuthors()
 *
 */
@@ -1120,7 +1120,7 @@ Authorlist.prototype._fnValidateAffiliations = function( aaoAffiliations, asErro
         var sAcronym = aoAffiliation[ Authorlist.INDICES.Acronym ];
         var sAddress = aoAffiliation[ Authorlist.INDICES.Address ];
 
-        // If acronym field is empty save it in missing acronyms, otherwise save 
+        // If acronym field is empty save it in missing acronyms, otherwise save
         // it in present acronyms
         var bAcronymEmpty = sAcronym.match( Authorlist.EMPTY ) !== null;
         if ( bAcronymEmpty ) {
@@ -1161,10 +1161,10 @@ Authorlist.prototype._fnValidateAffiliations = function( aaoAffiliations, asErro
 
 /*
 * Function: _fnValidateAuthors
-* Purpose:  Validates a subset - namely the authors - of the whole data of the 
-*           fnGetData() call in fnValidate. It makes sure that all paper names 
-*           and affiliations are present and linkable. At the same time it 
-*           generates errors messages if this is not the case and appends them 
+* Purpose:  Validates a subset - namely the authors - of the whole data of the
+*           fnGetData() call in fnValidate. It makes sure that all paper names
+*           and affiliations are present and linkable. At the same time it
+*           generates errors messages if this is not the case and appends them
 *           to the passed error messages array.
 * Input(s): array array object:aaoAuthors - the authors data entry
             array string:asErrors - the error messages array
@@ -1222,12 +1222,12 @@ Authorlist.prototype._fnValidateAuthors = function( aaoAuthors, asAcronyms, asEr
 /*
 * Function: _fnValidateUmbrellas
 * Purpose:  Validates a subset - namely the umbrella organizatons - of the whole
-*           data as retrieved by the fnGetData() call in fnValidate. It ensures 
+*           data as retrieved by the fnGetData() call in fnValidate. It ensures
 *           that each umbrella acronym is present in the list of all acronyms.
-*           Otherwise is generates a error message and appends it to the error 
-*           messages array. 
+*           Otherwise is generates a error message and appends it to the error
+*           messages array.
 * Input(s): array array object:aaoAffiliations - the affiliations data entry
-*           array string:asAcronyms - an array containing all the acronyms in 
+*           array string:asAcronyms - an array containing all the acronyms in
 *                                     the affiliations table
 *           array string:asErrors - the error messages array
 * Returns:  void
@@ -1247,7 +1247,7 @@ Authorlist.prototype._fnValidateUmbrellas = function( aaoAffiliations, asAcronym
         }
     } );
 
-    // Invalid umbrellas present? 
+    // Invalid umbrellas present?
     if ( asInvalidUmbrellas.length > 0 ) {
         var sInvalidError = '<strong>Unknown</strong> umbrella organization in line(s): ';
         sInvalidError += '<strong>' + asInvalidUmbrellas.join( ',' ) + '</strong>';
@@ -1273,8 +1273,8 @@ AuthorlistIndex.TO_MILLIS = 1000;
 
 /*
 * Variable: AuthorlistIndex.CSS
-* Purpose:  Central enumeration and mapping for the CSS classes used in the 
-*           AuthorlistIndex prototype. Eases consistent look up and renaming if 
+* Purpose:  Central enumeration and mapping for the CSS classes used in the
+*           AuthorlistIndex prototype. Eases consistent look up and renaming if
 *           required.
 
 *
@@ -1306,7 +1306,7 @@ AuthorlistIndex.CSS = {
 
 * Function: AuthorlistIndex
 * Purpose:  Constructor
-* Input(s): string:sId - Id of the html element the AuthorlistIndex will be 
+* Input(s): string:sId - Id of the html element the AuthorlistIndex will be
 *                        embedded into (preferably a div).
 * Returns:  AuthorlistIndex instance when called with new, else undefined
 *
@@ -1324,8 +1324,8 @@ AuthorlistIndex.prototype._fnCreateButton = Authorlist.prototype._fnCreateButton
 
 /*
 * Function: _fnCloneClicked
-* Purpose:  Defines the callback for clicking on a clone link on a respective 
-*           paper container. Sends a request to the server to clone the paper 
+* Purpose:  Defines the callback for clicking on a clone link on a respective
+*           paper container. Sends a request to the server to clone the paper
 *           and displays it in the list on success or outputs an error.
 * Input(s): node:nParent - the paper container of the clicked clone link
 *           string:sId - the id of the clicked paper
@@ -1355,8 +1355,8 @@ AuthorlistIndex.prototype._fnCloneClicked = function( nPaper, sId ) {
 
 /*
 * Function: _fnCreatePaper
-* Purpose:  Creates a single paper record node based on the data passed in the 
-*           oPaper object. 
+* Purpose:  Creates a single paper record node based on the data passed in the
+*           oPaper object.
 * Input(s): string:sLabel - label string
 *           string:sDetail - the detail string
 * Returns:  node:nWrapper - the paper detail node
@@ -1386,8 +1386,8 @@ AuthorlistIndex.prototype._fnCreateEditLinks = function( nParent, sId ) {
 
 /*
 * Function: _fnCreateNewButton
-* Purpose:  Creates the new button that allows users to create a new document. 
-*           Refers the user to a clean new sheet. The button is placed on the 
+* Purpose:  Creates the new button that allows users to create a new document.
+*           Refers the user to a clean new sheet. The button is placed on the
 *           passed parent element.
 * Input(s): node:nParent - the parent node
 * Returns:  void
@@ -1408,8 +1408,8 @@ AuthorlistIndex.prototype._fnCreateNewButton = function( nParent ) {
 
 /*
 * Function: _fnCreatePaper
-* Purpose:  Creates a single paper record node based on the data passed in the 
-*           oPaper object. 
+* Purpose:  Creates a single paper record node based on the data passed in the
+*           oPaper object.
 * Input(s): string:sLabel - label string
 *           string:sDetail - the detail string
 * Returns:  node:nWrapper - the paper detail node
@@ -1470,7 +1470,7 @@ AuthorlistIndex.prototype._fnCreatePaper = function( oPaper ) {
 
 /*
 * Function: _fnCreatePaperDetail
-* Purpose:  Creates a paper detail consisting of a label as defined in the 
+* Purpose:  Creates a paper detail consisting of a label as defined in the
 *           string sLabel with the values sDetail
 * Input(s): string:sLabel - label string
 *           string:sDetail - the detail string
@@ -1492,10 +1492,10 @@ AuthorlistIndex.prototype._fnCreatePaperDetail = function( sLabel, sDetail ) {
 
 /*
 * Function: _fnDeleteClicked
-* Purpose:  Defines the callback for clicking a delete link. On confirmation by 
-*           the user a request is sent a request to the server to delete the 
-*           paper. Afterwards the paper is removed from the list of all papers. 
-*           If an error occurs during the communication an error message is 
+* Purpose:  Defines the callback for clicking a delete link. On confirmation by
+*           the user a request is sent a request to the server to delete the
+*           paper. Afterwards the paper is removed from the list of all papers.
+*           If an error occurs during the communication an error message is
 *           displayed instead.
 * Input(s): node:nParent - the paper container where the delete link was clicked
 *           string:sId - the id of the clicked paper
@@ -1528,7 +1528,7 @@ AuthorlistIndex.prototype._fnDeleteClicked = function( nPaper, sId ) {
 
 /*
 * Function: _fnDisplay
-* Purpose:  Displays each of the passed papers in the oData object on the 
+* Purpose:  Displays each of the passed papers in the oData object on the
 *           nParent element.
 * Input(s): object:oData - the object containing all papers
 *           node:nParent - the element to display the papers on
@@ -1555,7 +1555,7 @@ AuthorlistIndex.prototype._fnDisplay = function( oData, nParent ) {
 
 /*
 * Function: _fnDisplayClonedPaper
-* Purpose:  Displays a new paper that is added to the list of all papers on the 
+* Purpose:  Displays a new paper that is added to the list of all papers on the
 *           front page
 * Input(s): node:nParent - the node containing the to be cloned paper
 *           object:oData - the data of the newly cloned paper
@@ -1569,7 +1569,7 @@ AuthorlistIndex.prototype._fnDisplayClonedPaper = function( nParent, oData ) {
 
 /*
 * Function: _fnDisplayEmptyDatabase
-* Purpose:  Gives a short note to the user that there are no records in the 
+* Purpose:  Gives a short note to the user that there are no records in the
 *           database and therefore nothing else can be displayed.
 * Input(s): node:nParent - the node indicating where to display the message
 * Returns:  void
@@ -1611,7 +1611,7 @@ AuthorlistIndex.prototype._fnRemovePaper = function( nParent ) {
 
 /*
 * Function: _fnRetrieve
-* Purpose:  Retrieves all available papers from the database and displays them 
+* Purpose:  Retrieves all available papers from the database and displays them
 *           nicely on the webpage on success.
 * Input(s): node:nParent - the parent element where to display the records
 * Returns:  void
@@ -1704,7 +1704,7 @@ Paper.prototype.fnGetData = function() {
 
 /*
 * Function: fnLoadData
-* Purpose:  Loads data from the passed object (same layout as generated in 
+* Purpose:  Loads data from the passed object (same layout as generated in
 *           fnGetData()) as the preset values
 * Input(s): object:oData - the fnGetData()-like load object
 * Returns:  void
@@ -1735,7 +1735,7 @@ Paper.prototype._fnCreateButton = Authorlist.prototype._fnCreateButton;
 
 /*
 * Function: _fnCreateButtons
-* Purpose:  Creates the add and remove buttons next to the passed parent and 
+* Purpose:  Creates the add and remove buttons next to the passed parent and
 *           assigns callbacks to them.
 * Input(s): node:nParent - the parent node to which to append the buttons
 * Returns:  void

--- a/modules/webauthorlist/lib/authorlist_config.py
+++ b/modules/webauthorlist/lib/authorlist_config.py
@@ -72,7 +72,7 @@ class JSON:
     NAME                   = 4
     DOMAIN                 = 5
     MEMBER                 = 6
-    SPIRES_ID              = 7
+    INSPIRE_ID             = 7
 
 
 class AuthorsXML:
@@ -81,7 +81,7 @@ class AuthorsXML:
     MEMBER                 = 'member'
     NONMEMBER              = 'nonmember'
     ORGANIZATION_ID        = 'o'
-    SPIRES                 = 'SPIRES'
+    INSPIRE                = 'INSPIRE'
     TIME_FORMAT            = '%Y-%m-%d_%H:%M'
 
 

--- a/modules/webauthorlist/lib/authorlist_dblayer.py
+++ b/modules/webauthorlist/lib/authorlist_dblayer.py
@@ -28,15 +28,15 @@ def now():
 
 def clone(paper_id, user_id):
     """
-    Clones a whole paper data having the given id and returns the paper 
-    information of the clone as a dictionary. If the paper_id was a falsy value 
-    (None usually) or the id of the paper to be cloned does not exist in the 
+    Clones a whole paper data having the given id and returns the paper
+    information of the clone as a dictionary. If the paper_id was a falsy value
+    (None usually) or the id of the paper to be cloned does not exist in the
     database. The function will create a new empty record, save it and return it
     instead.
     """
     data = {}
     clone_id = clone_paper(paper_id, user_id)
-    
+
     if (clone_id == 0):
         data = load(None)
         clone_id = save(None, user_id, data)
@@ -44,150 +44,150 @@ def clone(paper_id, user_id):
         clone_references(paper_id, clone_id)
         clone_affiliations(paper_id, clone_id)
         clone_authors(paper_id, clone_id)
-    
+
     load_paper(clone_id, data)
     data[cfg.JSON.PAPER_ID] = clone_id
-    
+
     return data
-    
+
 def clone_paper(paper_id, user_id):
     """
-    Clones the general paper information - i.e. title, collaboration and 
-    experiment number. Furthermore, the last modified timestamp will be set 
-    to the current time. All of this is only done, if the requested paper id 
-    was found in the database, otherwise 0 is returned. This function 
-    should NOT be called alone as long as you are really sure that you want 
+    Clones the general paper information - i.e. title, collaboration and
+    experiment number. Furthermore, the last modified timestamp will be set
+    to the current time. All of this is only done, if the requested paper id
+    was found in the database, otherwise 0 is returned. This function
+    should NOT be called alone as long as you are really sure that you want
     to do this. Refer to clone() instead.
     """
     return run_sql("""INSERT INTO aulPAPERS (id, id_user, title, collaboration,
                       experiment_number, last_modified) SELECT %s, id_user, title,
                       collaboration, experiment_number, %s FROM aulPAPERS
                       WHERE id = %s;""", (None, now(), paper_id,))
-                          
+
 def clone_references(paper_id, clone_id):
     """
-    Clones the references of the paper with the given id and assigns the new 
+    Clones the references of the paper with the given id and assigns the new
     clone id instead. Returns the clone id again for convenience reasons. The
     function should NOT be used alone as long as you are really sure that you
     want to do this. Have a look on clone() instead.
     """
-    run_sql("""INSERT INTO aulREFERENCES (item, reference, paper_id) 
-               SELECT item, reference, %s FROM aulREFERENCES 
+    run_sql("""INSERT INTO aulREFERENCES (item, reference, paper_id)
+               SELECT item, reference, %s FROM aulREFERENCES
                WHERE paper_id = %s;""", (clone_id, paper_id,))
     return clone_id
-               
+
 def clone_affiliations(paper_id, clone_id):
     """
-    Clones the affiliations of the given paper id and assigns the clone id 
-    instead. Returns the clone id for convenience reasons. The function should 
-    NOT be used alone as long as you are really sure that you want to do this. 
+    Clones the affiliations of the given paper id and assigns the clone id
+    instead. Returns the clone id for convenience reasons. The function should
+    NOT be used alone as long as you are really sure that you want to do this.
     Have a look on clone() instead.
     """
-    run_sql("""INSERT INTO aulAFFILIATIONS (item, acronym, umbrella, 
-               name_and_address, domain, member, spires_id, paper_id) 
-               SELECT item, acronym, umbrella, name_and_address, 
-               domain, member, spires_id, %s FROM aulAFFILIATIONS 
+    run_sql("""INSERT INTO aulAFFILIATIONS (item, acronym, umbrella,
+               name_and_address, domain, member, spires_id, paper_id)
+               SELECT item, acronym, umbrella, name_and_address,
+               domain, member, spires_id, %s FROM aulAFFILIATIONS
                WHERE paper_id = %s;""", (clone_id, paper_id,))
     return clone_id
-               
+
 def clone_authors(paper_id, clone_id):
     """
     Clones the authors of the paper with the passed id and assigns the new clone
-    id instead. It also invokes the cloning of the affiliations of the authors. 
-    The clone id will be returned again for convenience reasons. The function 
-    should NOT be used alone as long as you are really sure that you want to do 
+    id instead. It also invokes the cloning of the affiliations of the authors.
+    The clone id will be returned again for convenience reasons. The function
+    should NOT be used alone as long as you are really sure that you want to do
     this. Have a look on clone() instead.
     """
-    run_sql("""INSERT INTO aulAUTHORS (item, family_name, given_name, 
-               name_on_paper, status, paper_id) 
-               SELECT item, family_name, given_name, name_on_paper, 
-               status, %s FROM aulAUTHORS 
+    run_sql("""INSERT INTO aulAUTHORS (item, family_name, given_name,
+               name_on_paper, status, paper_id)
+               SELECT item, family_name, given_name, name_on_paper,
+               status, %s FROM aulAUTHORS
                WHERE paper_id = %s;""", (clone_id, paper_id,))
     clone_author_affiliations(paper_id, clone_id)
     clone_author_identifiers(paper_id, clone_id)
     return clone_id
-    
+
 def clone_author_affiliations(paper_id, clone_id):
     """
-    Clones the affiliations of the authors of the paper with the given id and 
+    Clones the affiliations of the authors of the paper with the given id and
     assigns the new clone id to them. Returns the clone_id again for convenience
     reasons. Should NOT be used alone but only as part of clone() as long as you
     are not really sure what you are doing.
     """
-    run_sql("""INSERT INTO aulAUTHOR_AFFILIATIONS (item, affiliation_acronym, 
-               affiliation_status, author_item, paper_id) 
-               SELECT item, affiliation_acronym, affiliation_status, 
-               author_item, %s FROM aulAUTHOR_AFFILIATIONS 
+    run_sql("""INSERT INTO aulAUTHOR_AFFILIATIONS (item, affiliation_acronym,
+               affiliation_status, author_item, paper_id)
+               SELECT item, affiliation_acronym, affiliation_status,
+               author_item, %s FROM aulAUTHOR_AFFILIATIONS
                WHERE paper_id = %s;""", (clone_id, paper_id,))
     return clone_id
 
 def clone_author_identifiers(paper_id, clone_id):
     """
-    Clones the identifiers of the authors of the paper with the given id and 
+    Clones the identifiers of the authors of the paper with the given id and
     assigns the new clone id to them. Returns the clone_id again for convenience
     reasons. Should NOT be used alone but only as part of clone() as long as you
     are not really sure what you are doing.
     """
-    run_sql("""INSERT INTO aulAUTHOR_IDENTIFIERS (item, identifier_number, 
-               identifier_name, author_item, paper_id) 
-               SELECT item, identifier_number, identifier_name, 
-               author_item, %s FROM aulAUTHOR_IDENTIFIERS 
+    run_sql("""INSERT INTO aulAUTHOR_IDENTIFIERS (item, identifier_number,
+               identifier_name, author_item, paper_id)
+               SELECT item, identifier_number, identifier_name,
+               author_item, %s FROM aulAUTHOR_IDENTIFIERS
                WHERE paper_id = %s;""", (clone_id, paper_id,))
     return clone_id
-    
+
 def delete(paper_id):
     """
-    Deletes the paper with the given id completely from the database. There is 
-    no backup copy so better we sure that you want to do this :). Returns the 
+    Deletes the paper with the given id completely from the database. There is
+    no backup copy so better we sure that you want to do this :). Returns the
     id of the deleted paper again for convenience reasons.
     """
     data = {cfg.JSON.PAPER_ID : paper_id}
-    
+
     delete_paper(paper_id)
     delete_references(paper_id)
     delete_affiliations(paper_id)
     delete_authors(paper_id)
     delete_author_affiliations(paper_id)
     delete_author_identifiers(paper_id)
-    
+
     return data
-    
+
 def delete_paper(paper_id):
     """
-    Deletes the general informations of a paper without making any backup copy 
-    and safety net for the paper with the given id. Should NOT be used alone 
-    unless you are sure that you want to do this. Refer to delete() instead. 
+    Deletes the general informations of a paper without making any backup copy
+    and safety net for the paper with the given id. Should NOT be used alone
+    unless you are sure that you want to do this. Refer to delete() instead.
     Returns the paper_id for convenience reasons.
     """
     run_sql("""DELETE FROM aulPAPERS WHERE id = %s;""", (paper_id,))
     return paper_id
-    
+
 def delete_references(paper_id):
     """
-    Deletes the paper references from the database with the given id. It does 
-    not create any backup copy. Should NOT be used unless you are really sure 
-    that you want to do this. Refer to delete() instead. Returns the paper_id 
+    Deletes the paper references from the database with the given id. It does
+    not create any backup copy. Should NOT be used unless you are really sure
+    that you want to do this. Refer to delete() instead. Returns the paper_id
     for convenience reasons.
     """
     run_sql("""DELETE FROM aulREFERENCES WHERE paper_id = %s;""", (paper_id,))
     return paper_id
-    
+
 def delete_affiliations(paper_id):
     """
-    Deletes the affiliations of the paper with the given paper id completely 
+    Deletes the affiliations of the paper with the given paper id completely
     from the database. There is no safety net or backup copy. Should NOT be used
-    alone unless you are sure that you want to do this. Refer to delete() 
+    alone unless you are sure that you want to do this. Refer to delete()
     instead. Returns the paper id for convenience reasons.
     """
     run_sql("""DELETE FROM aulAFFILIATIONS WHERE paper_id = %s;""", (paper_id,))
     return paper_id
-    
+
 def delete_authors(paper_id):
     """
-    Deletes the authors of the paper with the given id completely from the 
-    database. There is no backup copy or safety net, make sure you want to do 
-    this. This function should NOT be used alone unless you know what you are 
-    doing. Refer to delete() instead. Returns the paper id for convenience 
+    Deletes the authors of the paper with the given id completely from the
+    database. There is no backup copy or safety net, make sure you want to do
+    this. This function should NOT be used alone unless you know what you are
+    doing. Refer to delete() instead. Returns the paper id for convenience
     reasons.
     """
     run_sql("""DELETE FROM aulAUTHORS WHERE paper_id = %s;""", (paper_id,))
@@ -195,22 +195,22 @@ def delete_authors(paper_id):
 
 def delete_author_affiliations(paper_id):
     """
-    Deletes the affiliations of each author that is part of the paper of the 
-    passed id. There is no backup copy or safety net, so make sure you want to 
+    Deletes the affiliations of each author that is part of the paper of the
+    passed id. There is no backup copy or safety net, so make sure you want to
     call this function. This function should NOT be called alone unless you know
-    what you are doing. Refer to delete() instead. Returns the paper id for 
+    what you are doing. Refer to delete() instead. Returns the paper id for
     convenience reasons.
     """
-    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS 
+    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS
                WHERE paper_id = %s;""", (paper_id,))
     return paper_id
 
 def delete_author_identifiers(paper_id):
     """
-    Deletes the identifiers of each author that is part of the paper of the 
-    passed id. There is no backup copy or safety net, so make sure you want to 
+    Deletes the identifiers of each author that is part of the paper of the
+    passed id. There is no backup copy or safety net, so make sure you want to
     call this function. This function should NOT be called alone unless you know
-    what you are doing. Refer to delete() instead. Returns the paper id for 
+    what you are doing. Refer to delete() instead. Returns the paper id for
     convenience reasons.
     """
     run_sql("""DELETE FROM aulAUTHOR_IDENTIFIERS
@@ -224,9 +224,9 @@ def itemize(id_user):
     as can be found in the authorlist_config.
     """
     data = {}
-    papers = run_sql("""SELECT id, title, collaboration, experiment_number, 
+    papers = run_sql("""SELECT id, title, collaboration, experiment_number,
                         last_modified FROM aulPAPERS WHERE id_user = %s
-                        ORDER BY last_modified DESC;""" % (id_user)) 
+                        ORDER BY last_modified DESC;""" % (id_user))
     out_papers = data.setdefault('data', [])
     for paper in papers:
         paper_id, title, collaboration, experiment_number, last_modified = paper
@@ -239,10 +239,10 @@ def itemize(id_user):
 
 def load(paper_id):
     """
-    Loads all data of a paper data set with the given paper id. If the paper id 
-    is a falsy value or is not yet in the database the function will create a 
-    basic empty paper object and return it including the requested id (a falsy 
-    value will just be reused without any modification). The returned object is 
+    Loads all data of a paper data set with the given paper id. If the paper id
+    is a falsy value or is not yet in the database the function will create a
+    basic empty paper object and return it including the requested id (a falsy
+    value will just be reused without any modification). The returned object is
     a dictionary using the standard keys as defined in authorlist_config.
     """
     data = {}
@@ -251,18 +251,18 @@ def load(paper_id):
     load_references(paper_id, data)
     load_affiliations(paper_id, data)
     load_authors(paper_id, data)
-    
+
     return data
-    
+
 def load_paper(paper_id, data):
     """
-    Loads only the general paper information of the given id and adds them to 
-    the passed data dictionary. Should NOT be used alone as long as you are not 
-    sure what you are doing. Refer to load() instead. Returns the paper id for 
+    Loads only the general paper information of the given id and adds them to
+    the passed data dictionary. Should NOT be used alone as long as you are not
+    sure what you are doing. Refer to load() instead. Returns the paper id for
     convenience reasons.
     """
-    paper = run_sql("""SELECT title, collaboration, experiment_number, 
-                       last_modified  FROM aulPAPERS 
+    paper = run_sql("""SELECT title, collaboration, experiment_number,
+                       last_modified  FROM aulPAPERS
                        WHERE id = %s;""", (paper_id,))
     if (not paper):
         # TODO add message here
@@ -270,81 +270,81 @@ def load_paper(paper_id, data):
         data[cfg.JSON.COLLABORATION]      = ''
         data[cfg.JSON.EXPERIMENT_NUMBER]  = ''
         data[cfg.JSON.LAST_MODIFIED]      = now()
-        
+
         return paper_id
-        
-    title, collaboration, experiment_number, last_modified = paper[ 0 ] 
+
+    title, collaboration, experiment_number, last_modified = paper[ 0 ]
     data[cfg.JSON.PAPER_TITLE]        = title
     data[cfg.JSON.COLLABORATION]      = collaboration
     data[cfg.JSON.EXPERIMENT_NUMBER]  = experiment_number
     data[cfg.JSON.LAST_MODIFIED]      = last_modified
-    
+
     return paper_id
-    
+
 def load_references(paper_id, data):
     """
     Lodas only the reference information of the paper with the given id and adds
-    them to the passed data dictionary. Should NOT be used alone as long as you 
+    them to the passed data dictionary. Should NOT be used alone as long as you
     are not sure what you are doing. Refer to load() instead. Returns the passed
     id for convenience reasons.
     """
-    references = run_sql("""SELECT reference FROM aulREFERENCES 
+    references = run_sql("""SELECT reference FROM aulREFERENCES
                             WHERE paper_id = %s;""", (paper_id,))
     reference_ids = [reference[0] for reference in references]
     data[cfg.JSON.REFERENCE_IDS] = reference_ids
-    
+
     return paper_id
-    
+
 def load_affiliations(paper_id, data):
     """
-    Loads only the affiliations information of the paper with the given id and 
+    Loads only the affiliations information of the paper with the given id and
     adds them to the passed data dictionary. Should NOT be used alone as long as
-    you do not know what you are doing. Refer to load() instead. Returns the 
+    you do not know what you are doing. Refer to load() instead. Returns the
     passed id for convenience reasons.
     """
     result = run_sql("""SELECT item, acronym, umbrella, name_and_address, domain,
-                        member, spires_id FROM aulAFFILIATIONS 
+                        member, spires_id FROM aulAFFILIATIONS
                         WHERE paper_id = %s ORDER BY item;""", (paper_id,))
     affiliations = data.setdefault(cfg.JSON.AFFILIATIONS_KEY, [])
-    
+
     for affiliation in result:
         item, acronym, umbrella, name, domain, member, spires_id = affiliation
-        affiliations.append([item + 1, '', acronym, umbrella, name, 
+        affiliations.append([item + 1, '', acronym, umbrella, name,
                              domain, bool(member), spires_id])
-        
+
     return data
 
 def load_authors(paper_id, data):
     """
-    Loads the authors information of the paper with the passed id and adds them 
-    to the passed data dicitionary. This function will automatically also load 
-    all affiliations of the respective author. Should NOT be used alone as long 
-    as you do not know what you are doing. Refer to load() instead. Returns the 
+    Loads the authors information of the paper with the passed id and adds them
+    to the passed data dicitionary. This function will automatically also load
+    all affiliations of the respective author. Should NOT be used alone as long
+    as you do not know what you are doing. Refer to load() instead. Returns the
     passed id for convenience reasons.
     """
-    result = run_sql("""SELECT item, family_name, given_name, name_on_paper, 
-                        status FROM aulAUTHORS 
+    result = run_sql("""SELECT item, family_name, given_name, name_on_paper,
+                        status FROM aulAUTHORS
                         WHERE paper_id = %s ORDER BY item;""", (paper_id,))
     authors = data.setdefault(cfg.JSON.AUTHORS_KEY, [])
-    
+
     for author in result:
         item, family_name, given_name, paper_name, status = author
         author_affiliations = load_author_affiliations(paper_id, item)
         author_identifiers = load_author_identifiers(paper_id, item)
         authors.append([item + 1, '', family_name, given_name, paper_name,
                         status, author_affiliations, author_identifiers])
-        
+
     return data
-    
+
 def load_author_affiliations(paper_id, author_id):
     """
-    Loads the affiliations of the author with the passed id that is part of the 
-    author lists of the paper with the given id. Should NOT be used alone as 
-    long as you are not sure what you are doing. Refer to load() instead. In 
+    Loads the affiliations of the author with the passed id that is part of the
+    author lists of the paper with the given id. Should NOT be used alone as
+    long as you are not sure what you are doing. Refer to load() instead. In
     this case the paper id is NOT returned but the author affiliations.
     """
-    result = run_sql("""SELECT affiliation_acronym, affiliation_status 
-                        FROM aulAUTHOR_AFFILIATIONS WHERE author_item = %s 
+    result = run_sql("""SELECT affiliation_acronym, affiliation_status
+                        FROM aulAUTHOR_AFFILIATIONS WHERE author_item = %s
                         AND paper_id = %s ORDER BY item;""", (author_id, paper_id,))
     author_affiliations = []
 
@@ -356,27 +356,27 @@ def load_author_affiliations(paper_id, author_id):
 
 def load_author_identifiers(paper_id, author_id):
     """
-    Loads the identifiers of the author with the passed id that is part of the 
-    author lists of the paper with the given id. Should NOT be used alone as 
-    long as you are not sure what you are doing. Refer to load() instead. In 
+    Loads the identifiers of the author with the passed id that is part of the
+    author lists of the paper with the given id. Should NOT be used alone as
+    long as you are not sure what you are doing. Refer to load() instead. In
     this case the paper id is NOT returned but the author affiliations.
     """
-    result = run_sql("""SELECT identifier_number, identifier_name 
-                        FROM aulAUTHOR_IDENTIFIERS WHERE author_item = %s 
+    result = run_sql("""SELECT identifier_number, identifier_name
+                        FROM aulAUTHOR_IDENTIFIERS WHERE author_item = %s
                         AND paper_id = %s ORDER BY item;""", (author_id, paper_id,))
     author_identifiers = []
-    
+
     for author_identifier in result:
         number, name = author_identifier
         author_identifiers.append([number, name])
-        
+
     return author_identifiers
 
 def save(paper_id, user_id, in_data):
     """
-    Saves the passed data dictionary using the standard authorlist_config keys 
-    in the database using the passed paper_id. If the id is falsy or not yet in 
-    the database a new data set is created, otherwise the old data set will be 
+    Saves the passed data dictionary using the standard authorlist_config keys
+    in the database using the passed paper_id. If the id is falsy or not yet in
+    the database a new data set is created, otherwise the old data set will be
     overwritten. Returns a dictionary the holds the id of the saved data set.
     """
     out_data = {}
@@ -394,10 +394,10 @@ def save(paper_id, user_id, in_data):
 
 def save_paper(paper_id, user_id, data):
     """
-    Saves the general paper information from the passed data dictionary using 
-    the standard authorlist_config keys of the paper with the given id. Updates 
+    Saves the general paper information from the passed data dictionary using
+    the standard authorlist_config keys of the paper with the given id. Updates
     the last modified timestamp. Should NOT be used alone as long as you are not
-    sure what you are doing. Refer to save() instead. Returns the paper if of 
+    sure what you are doing. Refer to save() instead. Returns the paper if of
     the dataset.
     """
     if (not paper_id):
@@ -423,7 +423,7 @@ def save_paper(paper_id, user_id, data):
 
     return run_sql("""INSERT INTO aulPAPERS (id, id_user, title, collaboration,
                       experiment_number, last_modified)
-                      VALUES (%s, %s, %s, %s, %s, %s) 
+                      VALUES (%s, %s, %s, %s, %s, %s)
                       ON DUPLICATE KEY UPDATE
                       title = %s,
                       collaboration = %s,
@@ -432,9 +432,9 @@ def save_paper(paper_id, user_id, data):
 
 def save_references(paper_id, data):
     """
-    Saves the references of the passed data dictionary using the standard 
-    authorlist_config keys of the paper data set with the given id. Should NOT 
-    be used alone as long as you are not sure what you are doing. Refer to 
+    Saves the references of the passed data dictionary using the standard
+    authorlist_config keys of the paper data set with the given id. Should NOT
+    be used alone as long as you are not sure what you are doing. Refer to
     save() instead. Returns the paper id.
     """
     reference_ids = data[cfg.JSON.REFERENCE_IDS]
@@ -445,32 +445,32 @@ def save_references(paper_id, data):
                       index,
                       reference,
                       paper_id,
-                      
+
                       # update values
                       reference)
-    
-        run_sql("""INSERT INTO 
+
+        run_sql("""INSERT INTO
                    aulREFERENCES (item, reference, paper_id)
                    VALUES (%s, %s, %s)
                    ON DUPLICATE KEY UPDATE
                    reference = %s;""", data_tuple)
-                   
-    # Delete old references that are out of bounds - i.e. have a higher index 
+
+    # Delete old references that are out of bounds - i.e. have a higher index
     # than the length of the reference list
-    run_sql("""DELETE FROM aulREFERENCES WHERE item >= %s AND paper_id = %s;""", 
+    run_sql("""DELETE FROM aulREFERENCES WHERE item >= %s AND paper_id = %s;""",
             (len(reference_ids), paper_id))
-            
+
     return paper_id
 
 def save_affliations(paper_id, data):
     """
-    Saves the affiliations of the passed data dictionary using the standard 
-    authorlist_config keys to the data set of the paper with the given id. 
-    Should NOT be used alone as long as you are not sure what you are doing. 
+    Saves the affiliations of the passed data dictionary using the standard
+    authorlist_config keys to the data set of the paper with the given id.
+    Should NOT be used alone as long as you are not sure what you are doing.
     Refer to save() instead. Returns the paper_id for convenience reasons.
     """
     affiliations = data[cfg.JSON.AFFILIATIONS_KEY]
-    
+
     for index, affiliation in enumerate(affiliations):
         data_tuple = (# insert values
                       index,
@@ -479,19 +479,19 @@ def save_affliations(paper_id, data):
                       affiliation[cfg.JSON.NAME],
                       affiliation[cfg.JSON.DOMAIN],
                       affiliation[cfg.JSON.MEMBER],
-                      affiliation[cfg.JSON.SPIRES_ID],
+                      affiliation[cfg.JSON.INSPIRE_ID],
                       paper_id,
-                      
+
                       # update values
                       affiliation[cfg.JSON.ACRONYM],
                       affiliation[cfg.JSON.UMBRELLA],
                       affiliation[cfg.JSON.NAME],
                       affiliation[cfg.JSON.DOMAIN],
                       affiliation[cfg.JSON.MEMBER],
-                      affiliation[cfg.JSON.SPIRES_ID])
-    
-        run_sql("""INSERT INTO 
-                   aulAFFILIATIONS (item, acronym, umbrella, name_and_address, 
+                      affiliation[cfg.JSON.INSPIRE_ID])
+
+        run_sql("""INSERT INTO
+                   aulAFFILIATIONS (item, acronym, umbrella, name_and_address,
                                     domain, member, spires_id, paper_id)
                    VALUES(%s, %s, %s, %s, %s, %s, %s, %s)
                    ON DUPLICATE KEY UPDATE
@@ -501,23 +501,23 @@ def save_affliations(paper_id, data):
                    domain = %s,
                    member = %s,
                    spires_id = %s;""", data_tuple)
-                   
-    # Delete old affiliations that are out of bounds - i.e. have a higher index 
+
+    # Delete old affiliations that are out of bounds - i.e. have a higher index
     # than the length of the affiliations list
-    run_sql("""DELETE FROM aulAFFILIATIONS WHERE item >= %s AND paper_id = %s;""", 
+    run_sql("""DELETE FROM aulAFFILIATIONS WHERE item >= %s AND paper_id = %s;""",
             (len(affiliations), paper_id))
-            
+
     return paper_id
-    
+
 def save_authors(paper_id, data):
     """
-    Saves the authors of the passed data dictionary using the standard 
-    authorlist_config keys in the database of the paper with the given id. 
-    Should NOT be used alone as long as you do not know what you are doing. 
+    Saves the authors of the passed data dictionary using the standard
+    authorlist_config keys in the database of the paper with the given id.
+    Should NOT be used alone as long as you do not know what you are doing.
     Refer to save() instead. Returns the paper_id.
     """
     authors = data[cfg.JSON.AUTHORS_KEY]
-    
+
     for index, author in enumerate(authors):
         data_tuple = (# insert values
                       index,
@@ -526,41 +526,41 @@ def save_authors(paper_id, data):
                       author[cfg.JSON.PAPER_NAME],
                       author[cfg.JSON.STATUS],
                       paper_id,
-                      
+
                       # update values
                       author[cfg.JSON.FAMILY_NAME],
                       author[cfg.JSON.GIVEN_NAME],
                       author[cfg.JSON.PAPER_NAME],
                       author[cfg.JSON.STATUS])
-                      
-        run_sql("""INSERT INTO 
-                   aulAUTHORS (item, family_name, given_name, name_on_paper, 
-                               status, paper_id) 
+
+        run_sql("""INSERT INTO
+                   aulAUTHORS (item, family_name, given_name, name_on_paper,
+                               status, paper_id)
                    VALUES(%s, %s, %s, %s, %s, %s)
                    ON DUPLICATE KEY UPDATE
                    family_name = %s,
                    given_name = %s,
                    name_on_paper = %s,
                    status = %s;""", data_tuple)
-                   
+
         save_author_affiliations(paper_id, index, len(authors),
                                  author[cfg.JSON.AFFILIATIONS])
         save_author_identifiers(paper_id, index, len(authors),
                                 author[cfg.JSON.IDENTIFIERS])
-                   
-    # Delete old authors that are out of bounds - i.e. have a higher index 
+
+    # Delete old authors that are out of bounds - i.e. have a higher index
     # than the length of the affiliations list
-    run_sql("""DELETE FROM aulAUTHORS WHERE item >= %s AND paper_id = %s;""", 
+    run_sql("""DELETE FROM aulAUTHORS WHERE item >= %s AND paper_id = %s;""",
             (len(authors), paper_id))
-            
+
     return paper_id
-        
+
 def save_author_affiliations(paper_id, author_id, number_of_authors, data):
     """
-    Saves the affiliations of the passed author using the data dictionary and 
-    the standard authorlist_config keys and the paper id. Deletes also all old 
-    entries that are 'out of bounds' facilitating the number_of_authors 
-    paramter. Should NOT be used alone as long as you do not exactly know what 
+    Saves the affiliations of the passed author using the data dictionary and
+    the standard authorlist_config keys and the paper id. Deletes also all old
+    entries that are 'out of bounds' facilitating the number_of_authors
+    paramter. Should NOT be used alone as long as you do not exactly know what
     you are doing. Refer to save() instead. Returns the paper id.
     """
     for index, affiliation in enumerate(data):
@@ -570,30 +570,30 @@ def save_author_affiliations(paper_id, author_id, number_of_authors, data):
                       affiliation[cfg.JSON.AFFILIATION_STATUS],
                       author_id,
                       paper_id,
-        
+
                       # update values
                       affiliation[cfg.JSON.AFFILIATION_ACRONYM],
                       affiliation[cfg.JSON.AFFILIATION_STATUS])
-                      
+
         run_sql("""INSERT INTO
-                   aulAUTHOR_AFFILIATIONS (item, affiliation_acronym, 
-                                           affiliation_status, author_item, 
+                   aulAUTHOR_AFFILIATIONS (item, affiliation_acronym,
+                                           affiliation_status, author_item,
                                            paper_id)
                    VALUES(%s, %s, %s, %s, %s)
                    ON DUPLICATE KEY UPDATE
                    affiliation_acronym = %s,
                    affiliation_status = %s;""", data_tuple)
-    
-    # Delete entries that the author does not have anymore               
-    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS WHERE item >= %s 
-               AND author_item = %s AND paper_id = %s;""", 
+
+    # Delete entries that the author does not have anymore
+    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS WHERE item >= %s
+               AND author_item = %s AND paper_id = %s;""",
             (len(data), author_id, paper_id))
-            
+
     # Delete entries of non existing author
-    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS WHERE author_item >= %s 
+    run_sql("""DELETE FROM aulAUTHOR_AFFILIATIONS WHERE author_item >= %s
                 AND paper_id = %s;""",
             (number_of_authors, paper_id))
-            
+
     return paper_id
 
 def save_author_identifiers(paper_id, author_id, number_of_authors, data):
@@ -617,24 +617,24 @@ def save_author_identifiers(paper_id, author_id, number_of_authors, data):
                       identifier[cfg.JSON.IDENTIFIER_NAME])
 
         run_sql("""INSERT INTO
-                   aulAUTHOR_IDENTIFIERS (item, identifier_number, 
-                                           identifier_name, author_item, 
+                   aulAUTHOR_IDENTIFIERS (item, identifier_number,
+                                           identifier_name, author_item,
                                            paper_id)
                    VALUES(%s, %s, %s, %s, %s)
                    ON DUPLICATE KEY UPDATE
                    identifier_number = %s,
                    identifier_name = %s;""", data_tuple)
-    
-    # Delete entries that the author does not have anymore               
-    run_sql("""DELETE FROM aulAUTHOR_IDENTIFIERS WHERE item >= %s 
-               AND author_item = %s AND paper_id = %s;""", 
+
+    # Delete entries that the author does not have anymore
+    run_sql("""DELETE FROM aulAUTHOR_IDENTIFIERS WHERE item >= %s
+               AND author_item = %s AND paper_id = %s;""",
             (len(data), author_id, paper_id))
-            
+
     # Delete entries of non existing author
-    run_sql("""DELETE FROM aulAUTHOR_IDENTIFIERS WHERE author_item >= %s 
+    run_sql("""DELETE FROM aulAUTHOR_IDENTIFIERS WHERE author_item >= %s
                 AND paper_id = %s;""",
             (number_of_authors, paper_id))
-            
+
     return paper_id
 
 def get_owner(paper_id):

--- a/modules/webauthorlist/lib/authorlist_web_tests.py
+++ b/modules/webauthorlist/lib/authorlist_web_tests.py
@@ -247,7 +247,7 @@ class InvenioWebAuthorlistWebTest(InvenioWebTestCase):
         # remove timestamp
         downloaded = re.sub("\n    <cal:creationDate>[^<].*</cal:creationDate>", '', downloaded)
         valid = """<?xml version="1.0" encoding="utf-8"?>
-<collaborationauthorlist xmlns:cal="http://www.slac.stanford.edu/spires/hepnames/authors_xml/" xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<collaborationauthorlist xmlns:cal="http://inspirehep.net/info/HepNames/tools/authors_xml/" xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <cal:experimentNumber>text_experiment_number</cal:experimentNumber>
     <cal:organizations>
         <foaf:Organization id="o0">
@@ -316,8 +316,8 @@ class InvenioWebAuthorlistWebTest(InvenioWebTestCase):
         downloaded = fopen.read()
         valid = """<?xml version="1.0"?>
 
-\\author{Banana, J.$^{o0}$}  
-\\author{Apple, M.$^{o0}$}  
+\\author{Banana, J.$^{o0}$}
+\\author{Apple, M.$^{o0}$}
 \\affiliation{$^{o0}$ example 100}
 
 """


### PR DESCRIPTION
- Updates WebAuthorList to use INSPIRE everywhere instead of SPIRES.
- Improves from XML and record by correctly recognizing and using
  INSPIRE IDs, URLs, and addresses.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
