### PR TITLE
refextract: support JINST pages

### DIFF
--- a/modules/docextract/lib/refextract_engine.py
+++ b/modules/docextract/lib/refextract_engine.py
@@ -513,7 +513,7 @@ def look_for_implied_ibids(splitted_citations):
                                    'title'      : current_journal['title'],
                                    'volume'     : volume,
                                    'year'       : numeration['year'],
-                                   'page'       : numeration['page'],
+                                   'page'       : numeration['page'] or numeration['jinst_page'],
                                    'page_end'   : numeration['page_end'],
                                    'is_ibid'    : True,
                                    'extra_ibids': []}

--- a/modules/docextract/lib/refextract_re.py
+++ b/modules/docextract/lib/refextract_re.py
@@ -443,9 +443,11 @@ re_year = ur"""
 re_page_prefix = ur"[pP]?[p]?\.?\s?"  # Starting page num: optional Pp.
 re_page_num = ur"[RL]?\w?\d+[cC]?"    # pagenum with optional R/L
 re_page_sep = ur"\s*-\s*"             # optional separator between pagenums
-re_page = re_page_prefix + \
-    u"(?P<page>" + re_page_num + u")(?:" + re_page_sep + \
-    u"(?P<page_end>" + re_page_num + u"))?"
+re_jinst_page = ur'(?P<jinst_page>[pP]\d{5}\d*)'
+re_page = ur"(%s|%s)" % (re_jinst_page, re_page_prefix +
+    u"(?P<page>" + re_page_num + u")(?:" + re_page_sep +
+    u"(?P<page_end>" + re_page_num + u"))?")
+
 
 # Series
 re_series = ur"(?P<series>[A-H])"

--- a/modules/docextract/lib/refextract_tag.py
+++ b/modules/docextract/lib/refextract_tag.py
@@ -459,7 +459,7 @@ def find_numeration_more(line):
             return {'year': info.get('year', None),
                     'series': series,
                     'volume': info['vol_num'],
-                    'page': info['page'],
+                    'page': info['page'] or info['jinst_page'],
                     'page_end': info['page_end'],
                     'len': len(info['aftertitle'])}
 
@@ -1096,7 +1096,7 @@ def find_numeration(line):
             return {'year': info.get('year', None),
                     'series': series,
                     'volume': info['vol_num'],
-                    'page': info['page'],
+                    'page': info['page'] or info['jinst_page'],
                     'page_end': info['page_end'],
                     'len': match.end()}
 


### PR DESCRIPTION
- Introduces support for JINST (and some other journals) article IDs
  which starts with P, where the P is actually part of the ID itself,
  and must not be stripped.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
