### PR TITLE
WebSearch: fix cited range search

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_searcher.py
+++ b/modules/bibrank/lib/bibrank_citation_searcher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -159,6 +159,8 @@ def get_records_with_num_cites(numstr, allrecs=intbitset([]),
         num = int(singlenum[0])
         if num == 0:
             #we return recids that are not in keys
+            if not allrecs:
+                allrecs = intbitset(run_sql("SELECT id FROM bibrec"))
             return allrecs - citations_keys
         else:
             return intbitset([recid for recid, cit_count
@@ -172,7 +174,9 @@ def get_records_with_num_cites(numstr, allrecs=intbitset([]),
         sec = int(firstsec[0][1])
         if first == 0:
             # Start with those that have no cites..
-    	    matches = allrecs - citations_keys
+            if not allrecs:
+                allrecs = intbitset(run_sql("SELECT id FROM bibrec"))
+            matches = allrecs - citations_keys
         if first <= sec:
             matches += intbitset([recid for recid, cit_count
                              in cache_cited_by_dictionary_counts

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2442,7 +2442,7 @@ def search_unit(p, f=None, m=None, wl=0, ignore_synonyms=None):
         hitset = search_unit_by_times_cited(p[6:])
     elif p.startswith("citedexcludingselfcites:"):
         # we are doing search by the citation count
-        hitset = search_unit_by_times_cited(p[6:], exclude_selfcites=True)
+        hitset = search_unit_by_times_cited(p[24:], exclude_selfcites=True)
     else:
         # we are doing bibwords search by default
         hitset = search_unit_in_bibwords(p, f, wl=wl)
@@ -2918,15 +2918,7 @@ def search_unit_by_times_cited(p, exclude_selfcites=False):
     Usually P looks like '10->23'.
     """
     numstr = '"'+p+'"'
-    #this is sort of stupid but since we may need to
-    #get the records that do _not_ have cites, we have to
-    #know the ids of all records, too
-    #but this is needed only if bsu_p is 0 or 0 or 0->0
-    allrecs = []
-    if p == 0 or p == "0" or \
-       p.startswith("0->") or p.endswith("->0"):
-        allrecs = intbitset(run_sql("SELECT id FROM bibrec"))
-    return get_records_with_num_cites(numstr, allrecs,
+    return get_records_with_num_cites(numstr,
                                       exclude_selfcites=exclude_selfcites)
 
 def search_unit_refersto(query):


### PR DESCRIPTION
```
* correctly handles ranges 00->..
* fixes term stripping for citedexcludingselfcites:
```

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com

fixes problems arising from initialization of allrecs to empty list instead of intbitset
fixes searches:   cited:00->10
fixes searches: topcite 00+
fixes an apparent copy&paste error in stripping of the term from search expression
