### PR TITLE
BibAuthorID: mysql optimization

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011, 2012, 2013 CERN.
+# Copyright (C) 2011, 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -2891,11 +2891,12 @@ def get_papers_affected_since(date_from, date_to=None):  # personid_get_recids_a
     @return type: intbitset
     """
     recs = run_sql("""select bibrec from aidPERSONIDPAPERS where
-                      last_updated >= %s or personid in
+                      last_updated >= %s UNION ALL select bibrec
+                      from aidPERSONIDPAPERS where personid in
                       (select personid from aidPERSONIDDATA where
                       last_updated >= %s)""", (date_from, date_from))
 
-    return intbitset([rec[0] for rec in recs])
+    return intbitset(recs)
 
 
 


### PR DESCRIPTION
I noticed that

bibauthorid_personid_maintenance.get_recids_affected_since()

takes ~25seconds on average.

Why is this? (beware of query cache when you time these. change the datetime
every query to get fresh measurement)

```

> explain select bibrec from aidPERSONIDPAPERS where last_updated
>="2015-12-11 00:00:13" or personid in (select personid from aidPERSONIDDATA where last_updated >="2015-12-01 00:00:13");
+------+--------------+-------------------+-------+------------------------+-------------+---------+------+---------+-----------------------+
| id   | select_type  | table             | type  | possible_keys          | key         | key_len | ref  | rows    | Extra                 |
+------+--------------+-------------------+-------+------------------------+-------------+---------+------+---------+-----------------------+
|    1 | PRIMARY      | aidPERSONIDPAPERS | ALL   | timestamp-b            | NULL        | NULL    | NULL | 9585799 | Using where           |
|    2 | MATERIALIZED | aidPERSONIDDATA   | range | personid-b,timestamp-b | timestamp-b | 4       | NULL |     747 | Using index condition |
+------+--------------+-------------------+-------+------------------------+-------------+---------+------+---------+-----------------------+
```

You see that the entire aidPERSONIDPAPERS table is scanned 9585799 rows

splitting that up into 2 separate queries with "UNION ALL" avoids the table
scan and uses the available indices. this executes over a thousand times
faster on prod

```
> explain (select bibrec from aidPERSONIDPAPERS where last_updated >="2015-12-11 00:00:13") UNION ALL (select bibrec from aidPERSONIDPAPERS where personid in(select personid from aidPERSONIDDATA where last_updated >="2015-12-01 00:00:13"));
+------+--------------+-------------------+-------+-----------------------------------------+-------------+---------+--------------------------------------+------+-----------------------+
| id   | select_type  | table             | type  | possible_keys                           | key         | key_len | ref                                  | rows | Extra                 |
+------+--------------+-------------------+-------+-----------------------------------------+-------------+---------+--------------------------------------+------+-----------------------+
|    1 | PRIMARY      | aidPERSONIDPAPERS | range | timestamp-b                             | timestamp-b | 4       | NULL                                 |    1 | Using index condition |
|    2 | UNION        | <subquery3>       | ALL   | distinct_key                            | NULL        | NULL    | NULL                                 |  747 |                       |
|    2 | UNION        | aidPERSONIDPAPERS | ref   | personid-b,pn-b,ptvrf-b,personid-flag-b | ptvrf-b     | 8       | inspiredemo.aidPERSONIDDATA.personid |   14 | Using index           |
|    3 | MATERIALIZED | aidPERSONIDDATA   | range | personid-b,timestamp-b                  | timestamp-b | 4       | NULL                                 |  747 | Using index condition |
| NULL | UNION RESULT | <union1,2>        | ALL   | NULL                                    | NULL        | NULL    | NULL                                 | NULL |                       |
+------+--------------+-------------------+-------+-----------------------------------------+-------------+---------+--------------------------------------+------+-----------------------+
```

unfortunately run_sql() doesn't recognize queries starting with an opening
paren '(SELECT ...)' as SELECT queries and only returns the number of
results. Doh!

But we don't need the outer parentheses!

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
