### PR TITLE
BibAuthorID: latest papers in person search

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -2997,6 +2997,12 @@ def get_papers_info_of_author(pid, flag,  # get_person_papers
         if show_date:
             record_info['date'] = (record_get_field_value(recstruct, '269', '', '', 'c'),)
 
+        try:
+            record_info['earliest_date'] = run_sql("SELECT earliest_date FROM bibrec WHERE id=%s", (rec, ))[0][0].strftime("%Y-%m-%d")
+        except:
+            # Too bad
+            pass
+
         if show_experiment:
             record_info['experiment'] = (record_get_field_value(recstruct, '693', '', '', 'e'),)
 

--- a/modules/bibauthorid/lib/bibauthorid_templates.py
+++ b/modules/bibauthorid/lib/bibauthorid_templates.py
@@ -1501,7 +1501,7 @@ class Template:
 
             for paper in papers:
                 h("<li>%s</li>"
-                  % (format_record(int(paper[0]), "ha")))
+                  % (format_record(int(paper), "ha")))
 
             h("</ul>")
         elif not papers:

--- a/modules/bibauthorid/lib/bibauthorid_webapi.py
+++ b/modules/bibauthorid/lib/bibauthorid_webapi.py
@@ -234,7 +234,7 @@ def get_most_frequent_name_from_pid(person_id=-1, allow_none=False):
             return "This person does not seem to have a name!"
 
 
-def get_papers_by_person_id(person_id=-1, rec_status=-2, ext_out=False):
+def get_papers_by_person_id(person_id=-1, rec_status=-2, ext_out=False, earliest_date_out=False):
     '''
     Returns all the papers written by the person
 
@@ -244,6 +244,8 @@ def get_papers_by_person_id(person_id=-1, rec_status=-2, ext_out=False):
     @type rec_status: int
     @param ext_out: Extended output (w/ author aff and date)
     @type ext_out: boolean
+    @param earliest_date_out: earliest_date output
+    @type earliest_date_out: boolean
 
     @return: list of record info
     @rtype: list of lists of info
@@ -269,9 +271,12 @@ def get_papers_by_person_id(person_id=-1, rec_status=-2, ext_out=False):
                                               show_affiliations=ext_out,
                                               show_date=ext_out,
                                               show_experiment=ext_out)
-    if not ext_out:
+    if not ext_out and not earliest_date_out:
         records = [[int(row["data"].split(",")[1]), row["data"], row["flag"],
                     row["authorname"]] for row in db_data]
+    elif not ext_out and earliest_date_out:
+        records = [[int(row["data"].split(",")[1]), row["data"], row["flag"],
+                    row["authorname"], row["earliest_date"]] for row in db_data]
     else:
         for row in db_data:
             recid = row["data"].split(",")[1]
@@ -281,10 +286,7 @@ def get_papers_by_person_id(person_id=-1, rec_status=-2, ext_out=False):
             rt_status = row['rt_status']
             authoraff = ", ".join(row['affiliation'])
 
-            try:
-                date = sorted(row['date'], key=len)[0]
-            except IndexError:
-                date = "Not available"
+            date = row.get('earliest_date', "Not available")
 
             exp = ", ".join(row['experiment'])
             # date = ""

--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -1937,8 +1937,8 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
             if req_type == 'getPapers':
                 if 'personId' in json_data:
                     pId = json_data['personId']
-                    papers = sorted([[p[0]] for p in webapi.get_papers_by_person_id(int(pId), -1)],
-                                    key=itemgetter(0))
+                    papers = [p[0] for p in sorted(webapi.get_papers_by_person_id(int(pId), -1, earliest_date_out=True),
+                                    key=itemgetter(4), reverse=True)]
                     papers_html = TEMPLATE.tmpl_gen_papers(papers[0:MAX_NUM_SHOW_PAPERS])
                     json_response.update({'result': "\n".join(papers_html)})
                     json_response.update({'totalPapers': len(papers)})


### PR DESCRIPTION
- Correctly sorts the latest 5 papers in the person search interface
  as expected by the heading "Recent Papers".

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
