### PR TITLE
BibSearch: fix for long journal terms

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2,7 +2,7 @@
 
 ## This file is part of Invenio.
 ## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009,
-##               2010, 2011, 2012, 2013, 2014, 2015 CERN.
+##               2010, 2011, 2012, 2013, 2014, 2015, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -2540,8 +2540,13 @@ def search_unit_in_bibwords(word, f, decompress=zlib.decompress, wl=0):
                     res = excp.res
                     limit_reached = 1 # set the limit reached flag to true
         else:
+            washedword = ''
+            if f == 'journal':
+                washedword = wash_index_term(word, 255)
+            else:
+                washedword = wash_index_term(word)
             res = run_sql("SELECT term,hitlist FROM %s WHERE term=%%s" % bibwordsX,
-                          (wash_index_term(word),))
+                          (washedword,))
     # fill the result set:
     for word, hitlist in res:
         hitset_bibwrd = intbitset(hitlist)


### PR DESCRIPTION
```
* journal word index term length is up to 255
  set length for wash_index_term accordingly
```

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com

quick fix for journal index based on bug reported by Florian:

In [1]: from invenio.search_engine import search_unit

In [2]: search_unit('Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5', 'journal')
intbitset([42396, 946645])

the correct answer would be:   intbitset([])

this is a BUG.

word = 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5'

wash_index_term(word)
'annales soc.sci.brux.ser.i sci.math.astron.phys.,a'

the string is still truncated at 50 char because that's the default in search_engine

def wash_index_term(term, max_char_length=50, lower_term=True):

T.

in detail:

rawref uses the journal index, which should have been corrected

In [1]: from invenio.search_engine import search_unit

In [2]: from invenio.refextract_api import search_from_reference

In [3]: search_from_reference('Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5')
('journal', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5')

In [4]: search_unit('Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5', 'journal')
intbitset([42396, 946645])

clearly the second shouldn't match

000042396 773__ $$c51-85$$pAnnales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.$$vA53$$y1933

000946645 773__ $$c49-59$$pAnnales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.$$vA47$$y1927

the journal WORD index looks ok

In [5]: from invenio.dbquery import run_sql

In [6]: from invenio.search_engine import deserialize_via_marshal

In [7]: deserialize_via_marshal(run_sql('select termlist from idxWORD09R where id_bibrec=42396')[0][0])
['Gen.Rel.Grav.,29,641-680', 'Gen.Rel.Grav.,29,641', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.', '641-680', '1997', '51', '29', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,51', '641', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,51-85', 'Gen.Rel.Grav.,29', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53', '51-85', 'Gen.Rel.Grav.', '1933', 'A53']

In [8]: deserialize_via_marshal(run_sql('select termlist from idxWORD09R where id_bibrec=946645')[0][0])
['Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.', '49-59', '49', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A47,49', 'A47', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A47,49-59', 'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A47', '1927']

so the WORD index for journal is ok. The lookup is problematic.

ipdb.runcall(search_unit, p="Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5", f='journal')

.....
ipdb> s

> /usr/lib64/python2.7/site-packages/invenio/search_engine.py(2543)search_unit_in_bibwords()
>    2542         else:
> -> 2543             res = run_sql("SELECT term,hitlist FROM %s WHERE term=%%s" % bibwordsX,
>    2544                           (wash_index_term(word),))

ipdb> p word
'Annales Soc.Sci.Brux.Ser.I Sci.Math.Astron.Phys.,A53,5'
ipdb> p bibwordsX
'idxWORD09F'
ipdb> p wash_index_term(word)
'annales soc.sci.brux.ser.i sci.math.astron.phys.,a'
ipdb> quit
