### PR TITLE
bibclassify: find combinations even if components are not found

### DIFF
--- a/modules/bibclassify/lib/bibclassify_keyword_analyzer.py
+++ b/modules/bibclassify/lib/bibclassify_keyword_analyzer.py
@@ -140,7 +140,7 @@ def get_composite_keywords(ckw_db, fulltext, skw_spans):
         except KeyError:
             # Some of the keyword components are not to be found in the text.
             # Therefore we cannot continue because the match is incomplete.
-            continue
+            pass
 
 
         ckw_spans = []


### PR DESCRIPTION
- Removes a bug in bibclassify_keyword_analyzer.py. If a combination
  is found via a synonym or regexp it is no longer thrown away
  just because the components of the combination are not found
  in the text.

Signed-off-by: fschwenn florian.schwennsen@desy.de
