### PR TITLE
DocExtract: fix books.kb

### DIFF
--- a/modules/docextract/etc/books.kb
+++ b/modules/docextract/etc/books.kb
@@ -187,9 +187,9 @@ Balachandran, A.P.|LECTURES ON GROUP THEORY FOR PHYSICISTS|1986;
 Balakin, Alexander B.|Non-minimal Einstein-Yang-Mills-dilaton theory|2008;
 Balakrishnan, A.V.|Applied Functional Analysis. Application of Mathematics. 3.|1976;
 Balashov, V.V.|Interaction of particles and radiation with matter|1997;
-Baldini, A.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GRP. 1: NUCLEAR AND PARTICLE PHYSICS. VOL. 12: TOTAL CROSS-SECTIONS FOR REACTIONS OF HIGH-ENERGY PARTICLES (INCLUDING ELASTIC, TOPOLOGICAL,
-Baldini, A.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GRP. 1: NUCLEAR AND PARTICLE PHYSICS. VOL. 12: TOTAL CROSS-SECTIONS FOR REACTIONS OF HIGH-ENERGY PARTICLES (INCLUDING ELASTIC, TOPOLOGICAL,
-Baldo Ceolin, Milla, (ed.)|Third NO-VE International Workshop on Neutrino Oscillations in Venice : Fifty years after the neutrino esperimental discovery : Venezia, February 7-10, 2006, Istituto Veneto di Scienze, Lettere ed
+Baldini, A.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GRP. 1: NUCLEAR AND PARTICLE PHYSICS. VOL. 12: TOTAL CROSS-SECTIONS FOR REACTIONS OF HIGH-ENERGY PARTICLES (INCLUDING ELASTIC, TOPOLOGICAL, INCLUSIVE AND EXCLUSIVE REACTIONS). SUBVOL|1988;
+Baldini, A.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GRP. 1: NUCLEAR AND PARTICLE PHYSICS. VOL. 12: TOTAL CROSS-SECTIONS FOR REACTIONS OF HIGH-ENERGY PARTICLES (INCLUDING ELASTIC, TOPOLOGICAL, INCLUSIVE AND EXCLUSIVE REACTIONS). SUBVOL|1988;
+Baldo Ceolin, Milla, (ed.)|Third NO-VE International Workshop on Neutrino Oscillations in Venice : Fifty years after the neutrino esperimental discovery : Venezia, February 7-10, 2006, Istituto Veneto di Scienze, Lettere ed Arti, Campo Santo Stefano|2006;
 Bali, G.|Two quark potentials|2004;
 Balian, R.|Methods in Field Theory. Les Houches Summer School in Theoretical Physics. Session 28, July 28-September 6, 1975|1976;
 Balian, R.|Structural Analysis of Collision Amplitudes. Lectures Delivered at Les Houches, Summer School in Theoretical Physics, June 1975|1976;
@@ -356,14 +356,14 @@ Blaha, S.|A derivation of electroweak theory based on an extension of special re
 Blaha, S.|A finite unified quantum field theory of the elementary particle standard model and quantum gravity: Based on new quantum dimensions and a new paradigm in the calculus of variations|2003;
 Blaha, S.|Physics beyond the light barrier: The source of parity violation, tachyons, and a derivation of standard model features|2006;
 Blaha, S.|Quantum big bang cosmology: Complex space-time general relativity, quantum coordinates, dodecahedral universe, inflation, and new spin 0, 1/2, 1 and 2 tachyons and imagyons|2004;
-Blaha, S.|Quantum theory of the third kind: A new type of divergence-free quantum field theory supporting a unified standard model of elementary particles and quantum gravity based on a new method in the calculus of
+Blaha, S.|Quantum theory of the third kind: A new type of divergence-free quantum field theory supporting a unified standard model of elementary particles and quantum gravity based on a new method in the calculus of variations|2005;
 Blaha, S.|The equivalence of elementary particle theories and computer languages: Quantum computers, Turing machines, standard model, superstring theory, and a proof that Goedel's theorem implies nature must be quantum|2005;
 Blaha, S.|The metatheory of physics theories, and the theory of everything as a quantum computer language|2005;
 Blaha, Stephen|A complete derivation of the form of the standard model with a new method to generate particle masses|2008;
 Blaha, Stephen|A direct derivation of the form of the standard model from GL(16)|2008;
 Blaha, Stephen|From asynchronous logic to the standard model to superflight to the stars|2011;
 Blaha, Stephen|Relativistic quantum metaphysics: A first principles basis for the standard model of elementary particles|2009;
-Blaha, Stephen|The origin of the standard model: The genesis of four quark and lepton species, parity violation, the electroweak sector, colour SU(3), three visible generations of fermions, and one generation of dark matter
+Blaha, Stephen|The origin of the standard model: The genesis of four quark and lepton species, parity violation, the electroweak sector, colour SU(3), three visible generations of fermions, and one generation of dark matter with dark energy|2005;
 Blaha, Stephen|The standard model's form derived from operator logic, superluminal transformations and GL(16). Relativistic quantum metaphysics|2008;
 Blair, D.G., (ed.)|The Detection of gravitational waves|1991;
 Blair, D.|Ripples on a cosmic sea: The search for gravitational waves|1998;
@@ -524,7 +524,7 @@ Byers, Nina, (ed.)|Out of the shadows, contributions of twentieth-century women 
 Byrne, J.|Neutrons, nuclei and matter|1993;
 Bystricky, J.|Nucleon Nucleon Scattering Data. 1.|1978;
 Bystricky, J.|Nucleon Nucleon Scattering Data. 2.|1978;
-Bystricky, J.|Numerical Data and Functional Relationships in Science and Technology. Group I: Nuclear and Particle Physics. Vol. 9: Elastic and Charge Exchange Scattering of Elementary Particles. a: Nucleon Nucleon and Kaon
+Bystricky, J.|Numerical Data and Functional Relationships in Science and Technology. Group I: Nuclear and Particle Physics. Vol. 9: Elastic and Charge Exchange Scattering of Elementary Particles. a: Nucleon Nucleon and Kaon Nucleon scattering|1980;
 Bytsenko, A.A.|Analytic aspects of quantum fields|2003;
 Cabannes, H.|Pade Approximants Method and Its Applications to Mechanics|1976;
 Cabibbo, N., (ed.)|Lepton physics at CERN and Frascati|1995;
@@ -587,7 +587,7 @@ Castellani, L.|Supergravity and superstrings: A Geometric perspective. Vol. 3: S
 Cegla, W., (ed.)|Twentyfive + 1 Karpacz Winter Schools in Theoretical Physics 1964 - 1990: List of lectures|1990;
 Celenza, L.S.|Relativistic nuclear physics: Theories of structure and scattering|1986;
 Ceolin, Milla Baldo, (ed.)|Eleventh International Workshop on Neutrino Telescopes, Venezia, February 22-25, 2005|2005;
-Ceolin, Milla Baldo, (ed.)|Fourth NO-VE International Workshop on Neutrino Oscillations in Venice : Ten years after the neutrino oscillations!! : Venezia, April 15-18, 2008, Istituto Veneto di Scienze, Lettere ed Arti, Campo
+Ceolin, Milla Baldo, (ed.)|Fourth NO-VE International Workshop on Neutrino Oscillations in Venice : Ten years after the neutrino oscillations!! : Venezia, April 15-18, 2008, Istituto Veneto di Scienze, Lettere ed Arti, Campo Santo Stefano|2008;
 Cerny, J.|Nuclear Spectroscopy and Reactions. Part A|1974;
 Cerny, J.|Nuclear Spectroscopy and Reactions. Part B|1974;
 Chadan, K.|Inverse Problems in Quantum Scattering Theory|1977;
@@ -649,7 +649,7 @@ Clarke, J.A.|The science and technology of undulators and wigglers|2004;
 Clay, Roger W.|Cosmic bullets: High energy particles in astrophysics|1998;
 Clifton, R., (ed.)|Perspectives on quantum reality: Nonrelativistic, relativistic, and field theoretic|1996;
 Cline, D.B., (ed.)|Weak neutral currents: The discovery of the electro-weak force|1997;
-Cline, D.B.|Unification of Elementary Forces and Gauge Theories. Papers Presented at the Ben Lee Memorial International Conference on Parity Nonconservation Weak Neutral Currents and Gauge Theories, Fermi National Accelerator
+Cline, D.B.|Unification of Elementary Forces and Gauge Theories. Papers Presented at the Ben Lee Memorial International Conference on Parity Nonconservation Weak Neutral Currents and Gauge Theories, Fermi National Accelerator Laboratory, Batavia|1977;
 Close, F.E.|AN INTRODUCTION TO QUARKS AND PARTONS|1979;
 Close, F.|Lucifer's legacy: The meaning of asymmetry|2000;
 Close, F.|Particle physics: A very short introduction|2004;
@@ -788,7 +788,7 @@ Delaney, C.F.G.|Radiation detectors: Physical principles and applications|1992;
 Deligne, P., (Ed.)|Quantum fields and strings: A course for mathematicians. Vol. 1, 2|1999;
 Deloff, A.|Fundamentals in hadronic atom theory|2003;
 Delphenich, D.H.|Nonlinear optical analogies in quantum electrodynamics|2006;
-Delsanto, P.P., (ed.)|New perspectives on problems in classical and quantum physics: A festschrift in honor of Herbert Ueberall. Part I: Radiation and solid state physics, nuclear and high-energy physics, mathematical
+Delsanto, P.P., (ed.)|New perspectives on problems in classical and quantum physics: A festschrift in honor of Herbert Ueberall. Part I: Radiation and solid state physics, nuclear and high-energy physics, mathematical physics|1988;
 Demtroeder, W.|Experimental physics. Vol. 4: Nuclear, particle and astrophysics|1998;
 Derdzinski, A.|Geometry of the standard model of elementary particles|1992;
 Dermer, Charles D.|High energy radiation from black holes: Gamma rays, cosmic rays and neutrinos|2009;
@@ -1244,7 +1244,7 @@ Govaerts, J.|Hamiltonian quantization and constrained dynamics|1991;
 Govoni, Pietro, (ed.)|IPRD08, 11th Topical Seminar on Innovative Particle and Radiation Detectors, Siena, Italy, 1-4 October 2008|2009;
 Gracia-Bondia, Jose M.|Elements of noncommutative geometry|2001;
 Grandy, W.T.|Relativistic quantum mechanics of leptons and fields|1991;
-Granja, Carlos, (ed.)|Nuclear physics methods and accelerators in biology and medicine. Fourth International Summer School on Nuclear Physics Methods and Accelerators in Biology and Medicine, Prague, Czech Republic, 8-19 July
+Granja, Carlos, (ed.)|Nuclear physics methods and accelerators in biology and medicine. Fourth International Summer School on Nuclear Physics Methods and Accelerators in Biology and Medicine, Prague, Czech Republic, 8-19 July 2007|2007;
 Grassmann, H.|The top quark, Picasso and Mercedes-Benz or what is physics? (In German)|1997;
 Grawe, H.|ATOMIC AND NUCLEAR PHYSICS: FOUNDATIONS, ELEMENTARY PARTICLES, ATOMIC SHELL, ATOMIC NUCLEUS. (IN GERMAN)|1988;
 Greco, Mario (Ed.)|Bruno Touschek memorial lectures|2004;
@@ -1470,7 +1470,7 @@ Hoh, Fang-Chao|Scalar strong interaction hadron theory|2011;
 Hohler, G.|COLLECTIVE ION ACCELERATION|1979;
 Hohler, G.|ELASTIC AND CHARGE EXCHANGE SCATTERING OF ELEMENTARY PARTICLES. PION NUCLEON SCATTERING. TABLES OF DATA|1982;
 Hohler, G.|HANDBOOK OF PION NUCLEON SCATTERING|1979;
-Hohler, G.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GROUP I: NUCLEAR AND PARTICLE PHYSICS. VOL. 9: ELASTIC AND CHARGE EXCHANGE SCATTERING OF ELEMENTARY PARTICLES. B: PION NUCLEON SCATTERING. PT. 2:
+Hohler, G.|NUMERICAL DATA AND FUNCTIONAL RELATIONSHIPS IN SCIENCE AND TECHNOLOGY. GROUP I: NUCLEAR AND PARTICLE PHYSICS. VOL. 9: ELASTIC AND CHARGE EXCHANGE SCATTERING OF ELEMENTARY PARTICLES. B: PION NUCLEON SCATTERING. PT. 2: Methods And Results Of Phenomenologic|1984;
 Hollik, W.|Electroweak precision tests at LEP|2000;
 Holstein, Barry R., (ed.)|Annual review of nuclear and particle science, vol. 59|2009;
 Holstein, Barry R., (ed.)|Annual review of nuclear and particle science. Vol. 60|2010;
@@ -2277,7 +2277,7 @@ Novikov, Sergei P.|Modern geometric structures and fields|2006;
 Novozhilov, Yu.V.|Introduction to Elementary Particle Theory|1975;
 Nowak, Maciej A.|Chiral nuclear dynamics|1996;
 Noyes, H.P.|Bit-string physics: A finite and discrete approach to natural philosophy|2001;
-Noz, M.E., (Ed.)|SPECIAL RELATIVITY AND QUANTUM THEORY: A COLLECTION OF PAPERS OF THE POINCARE GROUP DEDICATED TO PROFESSOR EUGENE PAUL WIGNER ON THE 50TH ANNIVERSARY OF HIS PAPER ON 'UNITARY REPRESENTATIONS OF THE
+Noz, M.E., (Ed.)|SPECIAL RELATIVITY AND QUANTUM THEORY: A COLLECTION OF PAPERS OF THE POINCARE GROUP DEDICATED TO PROFESSOR EUGENE PAUL WIGNER ON THE 50TH ANNIVERSARY OF HIS PAPER ON 'UNITARY REPRESENTATIONS OF THE Inhomogeneous Lorentz Group'|1988;
 Nutku, Y., (ed.)|Conformal field theory|2000;
 Nyiri, J., (ed.)|The Gribov theory of quark confinement|2001;
 O'Raifeartaigh, L.|GROUP STRUCTURE OF GAUGE THEORIES|1986;


### PR DESCRIPTION
the static file books.kb is of general form    editor|title|year;
several lines with long titles were truncated
this corrects those

A new/updated/refreshed file should be generated, but I couldn't find the code to do so.
