### PR TITLE
global: use latest MathJax to avoid bar (|)

### DIFF
--- a/modules/bibauthorid/etc/templates/head.html
+++ b/modules/bibauthorid/etc/templates/head.html
@@ -20,7 +20,7 @@ MathJax.Hub.Config({
         messageStyle: "none"
         });
 </script>
-<script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript">
+<script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript">
 </script>
 
 {% if stylesheets %}

--- a/modules/miscutil/lib/htmlutils.py
+++ b/modules/miscutil/lib/htmlutils.py
@@ -444,7 +444,7 @@ def get_mathjax_header(https=False):
            $MJV variable in the root Makefile.am
     """
     if CFG_MATHJAX_HOSTING.lower() == 'cdn':
-        mathjax_path = "//cdn.mathjax.org/mathjax/2.5-latest"
+        mathjax_path = "//cdn.mathjax.org/mathjax/latest"
     else:
         mathjax_path = "/MathJax"
 


### PR DESCRIPTION
Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
