### PR TITLE
orcidutils: avoid iteration over None

### DIFF
--- a/modules/miscutil/lib/orcidutils.py
+++ b/modules/miscutil/lib/orcidutils.py
@@ -212,7 +212,8 @@ def get_dois_from_orcid(orcid_id, get_titles=False):
     try:
         for work in orcid_profile['works']['group']:
             try:
-                if work['identifiers']:
+                if work['identifiers'] and \
+                   work['identifiers']['identifier'] is not None:
                     for identifier in work['identifiers']['identifier']:
                         identifier_type = \
                             identifier['external-identifier-type'].lower()


### PR DESCRIPTION
avoid exceptions when work =  "{u'identifiers': {u'identifier': None}, ....

e.g.
- 2016-04-16 11:12:37 -> TypeError: 'NoneType' object is not iterable (orcidutils.py:216:get_dois_from_orcid)

*\* User details
No client information available

*\* Traceback details

Traceback (most recent call last):
  File "/usr/lib64/python2.6/site-packages/invenio/webauthorprofile_corefunctions.py", line 431, in _get_external_publications
    external_pubs['doi'] = get_orcid_pubs(person_id)
  File "/usr/lib64/python2.6/site-packages/invenio/webauthorprofile_corefunctions.py", line 411, in get_orcid_pubs
    orcid_dois = get_dois_from_orcid(orcid_id, get_titles=True)
  File "/usr/lib64/python2.6/site-packages/invenio/orcidutils.py", line 216, in get_dois_from_orcid
    for identifier in work['identifiers']['identifier']:
TypeError: 'NoneType' object is not iterable

*\* Stack frame details

Frame get_dois_from_orcid in /usr/lib64/python2.6/site-packages/invenio/orcidutils.py at line 216

``` python
-------------------------------------------------------------------------------
       213         for work in orcid_profile['works']['group']:
       214             try:
       215                 if work['identifiers']:
   -->  216                     for identifier in work['identifiers']['identifier']:
       217                         identifier_type = \
       218                             identifier['external-identifier-type'].lower()
       219                         value = identifier['external-identifier-id']
-------------------------------------------------------------------------------
```

```
                      ap =  '<orcid.orcid.MemberAPI object at 0x2dad0090>'
           orcid_profile =  "{u'employments': None, u'works': {u'group': [{u'identifiers': {u'identifier': [{u'external-identifier-type': u'arxiv', u'external-identifier-id': u'1503.08664'}, {u'external-identifier-type': u'doi', u'external-identifier-id': u'10.1016/j.nuclphysb.2015.09.021'}]}, u'work-summary': [{u'put-code': 19418553, u'title': {u'translated-title': None, u'subtitle': None, u'title': {u'value': u'Two-particle irreducible effective actions versus resummation: Analytic properties and self-consistency '}}, u' [...]
                     doi =  "u'10.1016/j.nuclphysb.2015.09.021'"
                   title =  "u'Two-particle irreducible effective actions versus resummation: Analytic properties and self-consistency '"
         identifier_type =  "u'doi'"
              get_titles =  'True'
                   value =  "u'10.1016/j.nuclphysb.2015.09.021'"
                    work =  "{u'identifiers': {u'identifier': None}, u'work-summary': [{u'put-code': 9767623, u'title': {u'translated-title': None, u'subtitle': None, u'title': {u'value': u'Effects of f(R) Gravity on the Gravitational Bound States of Ultra-cold Neutrons'}}, u'last-modified-date': {u'value': 1445408231919}, u'created-date': {u'value': 1377680800572}, u'visibility': u'PUBLIC', u'source': {u'source-orcid': {u'path': u'0000-0001-9438-900X', u'host': u'orcid.org', u'uri': u'http://orcid.org/0000-0001-9438-900X' [...]
            current_dois =  "[u'10.1016/j.nuclphysb.2015.09.021']"
```

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
