### PR TITLE
Batchuploader: add specific task name

### DIFF
--- a/modules/bibupload/lib/batchuploader.py
+++ b/modules/bibupload/lib/batchuploader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2010, 2011, 2013 CERN.
+## Copyright (C) 2010, 2011, 2013, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -105,7 +105,7 @@ def task_run_core():
                     shutil.copy(os.path.join(files_dir, metafile), filename)
                     # Send bibsched task
                     mode = "--" + folder
-                    jobid = str(task_low_level_submission('bibupload', 'batchupload', mode, filename))
+                    jobid = str(task_low_level_submission('bibupload', 'batchupload', mode, filename, '-N', 'daemon'))
                     # Move file to done folder
                     filename = metafile + "_" + time.strftime("%Y%m%d%H%M%S", time.localtime()) + "_" + jobid
                     os.rename(os.path.join(files_dir, metafile), os.path.join(files_done_dir, filename))


### PR DESCRIPTION
This adds a unique name to the bibupload task created by batchuploader via -N option to bibtask to distinguish it from other bibuploads.

The task will show as bibupload:daemon, e.g.

```
792644 bibupload:daemon        batchupload   2016-04-19 15:55:36       WAITING ...
```

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
