### PR TITLE
BibCatalog: mysql escape search terms

### DIFF
--- a/modules/bibcatalog/lib/bibcatalog_system_rt.py
+++ b/modules/bibcatalog/lib/bibcatalog_system_rt.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
+# Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -24,6 +24,9 @@ This is a subclass of BibCatalogSystem
 
 import os
 import re
+
+from MySQLdb import escape_string
+
 import rt
 from rt import AuthorizationError, UnexpectedResponse, requests, \
     ConnectionError, NotAllowed, APISyntaxError, BadRequest
@@ -295,6 +298,13 @@ class BibCatalogSystemRT(BibCatalogSystem):
 
         if not search_atoms:
             return tickets
+
+        # rt modules does not escape search parameters
+        for k, val in search_atoms.items():
+            try:
+                search_atoms[k] = escape_string(val)
+            except TypeError:
+                pass
 
         rt_instance = self._get_instance()
         tickets = rt_instance.search(**search_atoms)


### PR DESCRIPTION
The rt modules does its own query parsing and assembly of mysql query, however search terms need to be already mysql escaped, otherwise the parser raises an InvalidQueryError

e.g. for report-number NUPHYS2015-O'SULLIVAN in record/1454223

the apostrophe causes

```
2016-05-03 08:04:04 --> Unexpected error occurred: Invalid query: 'Wrong query, expecting a AGGREGATOR or CLOSE_PAREN in '(Queue='HEP_curation') AND (CF.{RecordID}='1454223') AND (Subject LIKE 'arXiv:1605.00612 NU
PHYS2015-O'>SULLIVAN<--here (#1454223)')' at /mnt/rt-4.2/sbin/../lib/RT/SQL.pm line 130..
```

this is triggered by /opt/cds-invenio/bin/bibcatalog --tickets=arxiv_curation .......

```
2016-05-03 08:04:02 --> Running template arxiv_curation for 1454223
2016-05-03 08:04:02 --> Ticket to be generated: <BibCatalogTicket(subject=arXiv:1605.00612 NUPHYS2015-O'SULLIVAN (#1454223),queue=HEP_curation,recid=1454223)>
```

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
