### PR TITLE
arxiv-pdf-checker: checking existing PDFs

### DIFF
--- a/modules/pdfchecker/lib/arxiv_pdf_checker.py
+++ b/modules/pdfchecker/lib/arxiv_pdf_checker.py
@@ -183,6 +183,14 @@ def download_one(recid, version):
 
         docs = BibRecDocs(recid)
         bibdocfiles = docs.list_latest_files(doctype="arXiv")
+        if not bibdocfiles:
+            # Maybe that this is one of those INSPIRE-PUBLIC with
+            # still an arXiv file in it
+            for name, bibdoc in docs.list_bibdocs_by_names().items():
+                if name.startswith('arXiv:'):
+                    bibdocfiles = bibdoc.list_latest_files()
+
+        bibdocfiles = [bibdocfile for bibdocfile in bibdocfiles if bibdocfile.get_superformat() == '.pdf']
 
         needs_update = False
         try:


### PR DESCRIPTION
- Improves checking of existing PDFs by not only considering
  doctypes, but also checking by docname, and considering only
  actual PDFs and not other formats.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
