### PR TITLE
WebSearch: fix sorting of CV

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -6810,6 +6810,10 @@ def prs_display_results(kwargs=None, results_final=None, req=None, of=None, sf=N
             prs_summarize_records(kwargs=kwargs, **kwargs)
         elif of in ['hcv', 'htcv', 'tlcv'] and CFG_INSPIRE_SITE:
             from invenio.search_engine_cvifier import cvify_records
+            if CFG_BIBSORT_ENABLED:
+                results_final_for_all_selected_colls = sort_records(
+                    req, results_final_for_all_selected_colls,
+                    sort_field=sf, sort_order='a', of=of, ln=ln)
             cvify_records(results_final_for_all_selected_colls, of, req, so)
         else:
             prs_print_records(kwargs=kwargs, **kwargs)


### PR DESCRIPTION
Currently the CV output formats simply sort by recid. Users strongly prefer sorting by date. This patch honors the selected sort field if bibsort is available.

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
