### PR TITLE
BibRank: ignore errata in citation lookup

### DIFF
--- a/modules/bibrank/etc/citation.cfg
+++ b/modules/bibrank/etc/citation.cfg
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2007, 2008, 2010, 2011, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -30,6 +30,7 @@ pubinfo_journal_title = 909C4p
 pubinfo_journal_pages = 909C4c
 pubinfo_journal_vol = 909C4v
 pubinfo_journal_year = 909C4y
+pubinfo_journal_erratum = 909C4m
 pubinfo_journal_format = "p v (y) c"
 first_author = 100__a
 additional_author = 700__a

--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -506,6 +506,7 @@ def get_tags_config(config):
             'year': config.get(function, "pubinfo_journal_year"),
             'journal': config.get(function, "pubinfo_journal_title"),
             'volume': config.get(function, "pubinfo_journal_volume"),
+            'erratum': config.get(function, "pubinfo_journal_erratum"),
         }
     except ConfigParser.NoOptionError:
         tags['publication'] = None
@@ -515,6 +516,7 @@ def get_tags_config(config):
             'year': tagify(parse_tag(tag['year'])),
             'journal': tagify(parse_tag(tag['journal'])),
             'volume': tagify(parse_tag(tag['volume'])),
+            'erratum': tagify(parse_tag(tag['erratum'])),
         }
 
     # alternate (hidden) form of pubinfo
@@ -559,6 +561,15 @@ def get_journal_info(record, tags):
         # like c->444 y->1999 p->"journal of foo",
         # v->20
         tagsvalues = {}
+        try:
+            tmp = field.get_subfield_values(tags['publication']['erratum'][5])[0]
+        except IndexError:
+            pass
+        else:
+            if tmp.lower() in ('erratum', 'corrigendum'):
+                write_message("skipping erratum publication info")
+                continue
+
         try:
             tmp = field.get_subfield_values(tags['publication']['journal'][5])[0]
         except IndexError:


### PR DESCRIPTION
This skips errata pubnotes in the citation lookup, since frequently there is more than one erratum on the same journal page and the attribution is ambiguous.

Possibly should check that there is a valid non-erratum pubnote in addition -- not sure that's necessary, though.

The corresponding citation.cfg file in the inspire repo has to be updated also. PR for that to follow.

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
