### PR TITLE
orcidutils: get_dois_from_orcid fix

### DIFF
--- a/modules/miscutil/lib/orcidutils.py
+++ b/modules/miscutil/lib/orcidutils.py
@@ -201,7 +201,7 @@ def get_dois_from_orcid(orcid_id, get_titles=False):
     orcid_profile = None
     if orcid_id:
         try:
-            orcid_profile = ap.read_record_member(orcid_id, 'activities')
+            orcid_profile = ap.read_record_public(orcid_id, 'activities')
         except RequestException:
             register_exception(alert_admin=True)
 


### PR DESCRIPTION
- Amends get_dois_from_orcid() to use read_record_public() rather
  read_record_member(), since the latter seems to now require a
  valid access token, which we don't have.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
