### PR TITLE
BibDocFile: get_docname_from_url fix

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -3712,7 +3712,7 @@ def decompose_bibdocfile_very_old_url(url):
 def get_docname_from_url(url):
     """Return a potential docname given a url"""
     path = urllib2.urlparse.urlsplit(urllib.unquote(url))[2]
-    filename = os.path.split(path)[-1]
+    filename = os.path.split(path)[-1] or 'fulltext'
     return file_strip_ext(filename)
 
 def get_format_from_url(url):


### PR DESCRIPTION
* Fixes get_docname_from_url() by always returning a document name.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>