### PR TITLE
BibRank: improve DOI lookup

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -1228,6 +1228,9 @@ def ref_analyzer(citation_informations, updated_recids, tags, config):
         step("DOI catchup", thisrecid, done, len(records_info['doi']))
         done += 1
 
+        # lookup info with and without doi: prefix
+        dois = dois + ['doi:' + doi for doi in dois if doi.startswith('10.')]
+
         for doi in dois:
             recids = get_recids_matching_query(p=doi,
                                                f=tags['refs_doi'],


### PR DESCRIPTION
Since approx 2013 DOIs in `999C5a` are stored with a prefix `doi:` to distinguish them from handles (prefix `hdl:`).

Bibrank was never adapted to use the prefix in the exact match lookup from DOI of citee (`0247_a`) into ref of citer `999C5a`. 

This patch does a lookup of both forms, with and without prefix to account for legacy refs and new form refs

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>