### PR TITLE
bibcheck: new move_pattern_to_field plugin

### DIFF
--- a/modules/bibcheck/lib/bibcheck_task.py
+++ b/modules/bibcheck/lib/bibcheck_task.py
@@ -59,7 +59,10 @@ from invenio.search_engine import \
     search_unit_in_bibxxx, \
     search_pattern
 from invenio.bibedit_utils import get_bibrecord
-from invenio.bibrecord import record_xml_output, record_add_field, record_modify_subfield
+from invenio.bibrecord import (record_xml_output,
+                               record_add_field,
+                               record_modify_subfield,
+                               record_get_subfields)
 from invenio.pluginutils import PluginContainer
 from invenio.intbitset import intbitset
 from invenio.dbquery import run_sql
@@ -465,6 +468,14 @@ class AmendableRecord(dict):
         self._query(position[:2] + (None,))[0].append((code, value))
         self.set_amended("Added subfield %s='%s' to field %s" % (code, value,
             position[0][:5]))
+
+    def get_subfields(self, position):
+        """
+        Returns a list of all subfields of the field at position (as returned
+        by ``iterfield``)
+        """
+        return record_get_subfields(self, position[0][:3],
+                                    field_position_local=position[1])
 
     def set_amended(self, message):
         """ Mark the record as amended """

--- a/modules/bibcheck/lib/plugins/move_pattern_to_field.py
+++ b/modules/bibcheck/lib/plugins/move_pattern_to_field.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2017 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""
+Bibcheck plugin to move values of fields matching some pattern to a new field.
+
+The new value is taken from the 'value' named group of 'pattern' (with the
+'(?P<value>regexp)' construct), if it matches the value of source_field and put
+into new_field. A subfield_filter can be specified to further restrict the
+source field and additional_subfields can optionally be set to a list of
+constant subfield (code, value) pairs to add.
+
+If there is a match, the original field is deleted. By default, the new field
+is only created if it does not result in a duplicate value. This behavior can
+be disabled by setting allow_duplicates to True.
+
+Example rules:
+
+    [move_KEKSCAN]
+
+    check = move_pattern_to_field
+    check.source_field = "8564_u"
+    check.new_field = "035__a"
+    check.pattern = "^(https?://)?www-lib.kek.jp/cgi-bin/img_index\\?(?P<value>(\\d{2})?\\d{7})$"
+    check.subfield_filter = ["y", "KEKSCAN"]
+    check.additional_subfields = [["9", "KEKSCAN"]]
+    check.allow_duplicates = false
+    filter_collection = HEP
+    filter_pattern = 8564_u:'kek.jp/cgi-bin' - 035__9:KEKSCAN
+
+"""
+
+
+import re
+
+from invenio.bibrecord import record_add_field, record_get_field_values
+
+def check_record(record, source_field, new_field, pattern, 
+                 subfield_filter=(None, None), additional_subfields=[], 
+                 allow_duplicates=False):
+
+    assert len(source_field) == 6
+    assert len(new_field) == 6
+
+    new_code = new_field[5]
+    new_field = {
+        'tag': new_field[:3],
+        'ind1': new_field[3],
+        'ind2': new_field[4],
+    }
+    delcount = 0
+    regex = re.compile(pattern)
+    existing_values = set(record_get_field_values(record, code=new_code, **new_field))
+
+    for pos, val in record.iterfield(source_field,
+                                     subfield_filter=subfield_filter):
+        if val:
+            match = regex.match(val)
+
+            if match:
+                new_subfields = []
+                new_value = match.group('value')
+
+                if allow_duplicates or (
+                        new_value != '' and new_value not in existing_values):
+                    existing_values.add(new_value)
+                    new_subfields.extend(additional_subfields)
+                    new_subfields.append((new_code, new_value),)
+                    record_add_field(record, subfields=new_subfields,
+                                     **new_field)
+
+                record.delete_field((pos[0][0:3], pos[1] - delcount, None))
+                delcount += 1
+
+                record.set_amended(
+                    "%s field '%s' containing '%s'"
+                    % ('Moved' if new_subfields else 'Removed',
+                       source_field, new_value))
+
+            else:
+                record.warn('no match for [%s] against [%s]' % (pattern, val))
+


### PR DESCRIPTION
* NEW generic plugin to create new fields based on the value of another
field specified by a pattern. This can perform the same task as many
8564 -> 035/037 movers with appropriate rules files (see example
provided). It also supersedes and hence closes inspirehep/inspire#259.

Signed-off-by: Micha Moskovic <michamos@gmail.com>