### PR TITLE
BibRank: fix handling of superseeded recs

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -903,7 +903,7 @@ def ref_analyzer(citation_informations, updated_recids, tags, config):
             return
 
         # Ignore cites from superseeded records
-        if get_fieldvalues(citer, '78502w'):
+        if get_fieldvalues(citer, '78502%'):
             return
 
         citations[citee].add(citer)


### PR DESCRIPTION
Patch to properly ignore cites from superseeded records, which can be characterized by `78502r` or `78502w` or both. It also makes this consistent with

https://github.com/inspirehep/invenio/blob/prod/modules/bibrank/lib/bibrank_citation_indexer.py#L127-L132
and
https://github.com/inspirehep/invenio/blob/prod/modules/bibrank/lib/bibrank_citation_indexer.py#L721



Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>