### PR TITLE
hepdata: no ticket for missing data

### DIFF
--- a/modules/miscutil/lib/hepdatadisplayutils.py
+++ b/modules/miscutil/lib/hepdatadisplayutils.py
@@ -685,9 +685,6 @@ def render_hepdata_dataset_html(dataset, recid, seq, display_link=True):
 
             c.append("</div></td>" % args)
             c.append("</tr>")
-        else:
-            from invenio.hepdatautils import create_hepdata_ticket
-            create_hepdata_ticket(dataset.recid, 'Data missing in 8564_u')
 
         # rendering column titles
         c.append("<tr>")


### PR DESCRIPTION
* Disables creating RT ticket for missing data. It's all on
  HEPData.net anyway.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>