### PR TITLE
WebAuthorProfile: co-author search w/o collaboration

### DIFF
--- a/modules/webauthorprofile/lib/webauthorprofile_templates.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_templates.py
@@ -519,7 +519,7 @@ class Template:
                         second_author = 'exactauthor:%s' % wrap_author_name_in_quotes_if_needed(canonical)
                     else:
                         second_author = 'exactauthor:"%s"' % name
-                    rec_query = baid_query + second_author + " -cn:'Collaboration' "
+                    rec_query = baid_query + second_author + " -cn:** "
                     lnk = " <a href='%s/author/profile/%s'> %s </a> (" % (CFG_SITE_URL, canonical, name) + create_html_link(websearch_templates.build_search_url(p=rec_query), {}, "%s" % (frequency,),) + ')'
                     content.append("%s" % lnk)
                 return "<br>\n".join(content)


### PR DESCRIPTION
The common prefix _"Collaboration"_ was removed from `710__g`
a while back. Using `cn:**` instead is the next best solution to excluding collaboration papers from co-author search. It does however also exclude conference papers with just a few members of a collaboration

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>