### PR TITLE
WebAuthorProfile: fix caching race condition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ h5py==2.3.1
 unittest2==0.5.1
 rt==1.0.8
 orcid
+retrying


### PR DESCRIPTION
    * avoid race condition in cache hierarchy

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>


The wapcache contains entries which are dependent on other entries. The proper order of correct `wapCACHE` computation for a person is given here:

https://github.com/inspirehep/invenio/blob/prod/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py#L440-L462

The author profile page request instead uses independent asynchronous calls for each box.

This leads to race conditions with non-deterministic results, e.g. 

https://github.com/inspirehep/invenio/blob/prod/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py#L175-L177

https://github.com/inspirehep/invenio/blob/prod/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py#L227-L228

https://github.com/inspirehep/invenio/blob/prod/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py#L240-L241

https://github.com/inspirehep/invenio/blob/prod/modules/webauthorprofile/lib/webauthorprofile_corefunctions.py#L253-L254

give different results if those values are currently being computed.

The computation of the dependent cache value should be delayed instead of using `[None, False]` as input. 

Currently the `wapCACHE` is truncated daily and so most values are computed on demand instead of precached in well defined order. In particular for `co-author` values without collaborations, which depends on a slow search of `collabtuples` this frequently gives wrong results.

