### PR TITLE
BibAuthorId: lower number of concurrent request

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid.js
+++ b/modules/bibauthorid/lib/bibauthorid.js
@@ -1929,7 +1929,7 @@ $(document).ready(function() {
       this.hooks = {};
 
       this.minTime = minTime || 5000; // Default to 5 seconds.
-      this.concurrentRequests = num || 8; // Default to 8.
+      this.concurrentRequests = num || 6; // Default to 6.
       this.baseUrl = "/author/profile/";
 
       displayLoading = function showLoadingSpinner( box ) {


### PR DESCRIPTION
tune number of concurrent requests from the individual boxes on the author profile pages to avoid HTTP Status 502 'Bad Gateway' 
errors

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>