### PR TITLE
bibupload: ditch PyPDF2 in favor of pdfinfo

### DIFF
--- a/modules/bibupload/lib/bibupload.py
+++ b/modules/bibupload/lib/bibupload.py
@@ -102,6 +102,7 @@ from invenio.bibdocfile import BibRecDocs, file_strip_ext, normalize_format, \
     KEEP_OLD_VALUE, decompose_bibdocfile_url, InvenioBibDocFileError, \
     bibdocfile_url_p, CFG_BIBDOCFILE_AVAILABLE_FLAGS, guess_format_from_url, \
     BibRelation, MoreInfo, guess_via_magic
+from invenio.shellutils import run_shell_command
 
 from invenio.search_engine import search_pattern
 
@@ -1995,11 +1996,8 @@ def elaborate_fft_tags(record, rec_id, mode, pretend=False,
                             guessed_format = guess_via_magic(downloaded_url)
                             if guessed_format != docformat:
                                 raise RuntimeError("Given URL %s was supposed to refer to format %s but was found to be of format %s. Is this document behind an authentication page?" % (url, docformat, guessed_format))
-                            from PyPDF2 import PdfFileReader
-                            from PyPDF2.utils import PdfReadError
-                            try:
-                                PdfFileReader(open(downloaded_url))
-                            except PdfReadError as err:
+                            exit_code, dummy_out, err = run_shell_command("pdfinfo %s", (downloaded_url,))
+                            if exit_code:
                                 raise RuntimeError("The provided PDF is corrupted: %s" % err)
                         write_message("%s saved into %s" % (url, downloaded_url), verbose=9)
                     except Exception, err:


### PR DESCRIPTION
* Certain documents currently fail with PyPDF2 despite being valid
  PDF documents. pdfinfo is simpler and therfore more robust.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>