### PR TITLE
WebAccess: disable IP check

### DIFF
--- a/modules/webaccess/lib/access_control_config.py
+++ b/modules/webaccess/lib/access_control_config.py
@@ -117,8 +117,8 @@ elif CFG_INSPIRE_SITE:
     CFG_EXTERNAL_AUTH_LOGOUT_SSO = None
     CFG_EXTERNAL_AUTHENTICATION = {
     "Local": None,
-    "Robot": ExternalAuthRobot(enforce_external_nicknames=True, use_zlib=False, check_user_ip=2, external_id_attribute_name='personid'),
-    "ZRobot": ExternalAuthRobot(enforce_external_nicknames=True, use_zlib=True, check_user_ip=2, external_id_attribute_name='personid')
+    "Robot": ExternalAuthRobot(enforce_external_nicknames=True, use_zlib=False, check_user_ip=0, external_id_attribute_name='personid'),
+    "ZRobot": ExternalAuthRobot(enforce_external_nicknames=True, use_zlib=True, check_user_ip=0, external_id_attribute_name='personid')
     }
 else:
     CFG_EXTERNAL_AUTH_DEFAULT = 'Local'


### PR DESCRIPTION
* Disables IP checking in Robot login, since it's just causing
  difficult to explain mal-functionment, rather than really
  protecting users.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>