### PR TITLE
WebAuthorProfile: https for image links as necessary

### DIFF
--- a/modules/webauthorprofile/lib/webauthorprofile_publication_grapher.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_publication_grapher.py
@@ -21,7 +21,7 @@ import os
 import time
 import tempfile
 
-from invenio.config import CFG_SITE_URL, CFG_WEBDIR
+from invenio.config import CFG_SITE_URL, CFG_SITE_SECURE_URL, CFG_WEBDIR
 
 cfg_gnuplot_available = 1
 try:
@@ -127,18 +127,19 @@ def create_graph_image(graph_file_name, graph_data, image_size=None):
 
     return graph_path
 
-def html_image(normal_image_path, icon_image_path):
+def html_image(normal_image_path, icon_image_path, https=False):
     """
     Returns html code for showing publication graph image (with lightbox js effect)
     @param normal_image_path: str (normal sized image name)
     @param icon_image_path: str (icon sized image name)
     @return: str (html code)
     """
+    siteurl = CFG_SITE_SECURE_URL if https else CFG_SITE_URL
     html = """<a href='%s/img/%s' rel="lightbox"> <img src='%s/img/%s' alt="">
-        </a>""" % (CFG_SITE_URL, normal_image_path, CFG_SITE_URL, icon_image_path)
+        </a>""" % (siteurl, normal_image_path, siteurl, icon_image_path)
     return html
 
-def get_graph_code(graph_file_name, graph_data):
+def get_graph_code(graph_file_name, graph_data, https=False):
     """
     Creates HTML code referring to the 'publications per year' graph image.
     If the image does not exist in the filesystem, it creates a new one.
@@ -159,5 +160,5 @@ def get_graph_code(graph_file_name, graph_data):
     normal_graph_path = get_graph_path(graph_file_name, graph_data)
     icon_graph_path = get_graph_path(graph_file_name + '_icon', graph_data, [350, 200])
 
-    html_graph_code = html_image(normal_graph_path, icon_graph_path)
+    html_graph_code = html_image(normal_graph_path, icon_graph_path, https=https)
     return html_graph_code

--- a/modules/webauthorprofile/lib/webauthorprofile_templates.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_templates.py
@@ -533,7 +533,7 @@ class Template:
 
         return content
 
-    def tmpl_graph_box(self, pubs_per_year, ln, loading=False):
+    def tmpl_graph_box(self, pubs_per_year, ln, loading=False, https=False):
         """ Creates a graph image (if it doesn't exist) with publication history over the years for
             the specific author and returns the image tag in HTML.
         """
@@ -552,7 +552,7 @@ class Template:
                         graph_data.append((year, 0))
 
                 graph_file_name = '%s' % (md5(str(graph_data)).hexdigest())
-                graph = get_graph_code(graph_file_name, graph_data)
+                graph = get_graph_code(graph_file_name, graph_data, https=https)
                 if graph:
                     graph_html = graph
         else:

--- a/modules/webauthorprofile/lib/webauthorprofile_webinterface.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_webinterface.py
@@ -664,8 +664,8 @@ class WebAuthorPages(WebInterfaceDirectory):
                 pubs_per_year, pubs_per_yearStatus = get_pubs_per_year(person_id)
                 if not pubs_per_year:
                     pubs_per_year = dict()
-
-                json_response = {'status': pubs_per_yearStatus, 'html': webauthorprofile_templates.tmpl_graph_box(pubs_per_year, ln='en', loading=not pubs_per_yearStatus)}
+                securelinks = req.is_https()
+                json_response = {'status': pubs_per_yearStatus, 'html': webauthorprofile_templates.tmpl_graph_box(pubs_per_year, ln='en', loading=not pubs_per_yearStatus, https=securelinks)}
                 req.content_type = 'application/json'
                 return json.dumps(json_response)
 


### PR DESCRIPTION
    * serve publication graph via https when the request
      is https
    * keeps image URL absolute to allow for a separate image
      server to be used

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>