### PR TITLE
BibAuthorId: replace strftime to handle dates<1900

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -3027,7 +3027,8 @@ def get_papers_info_of_author(pid, flag,  # get_person_papers
                 record_info['date'] = (date,)
 
         try:
-            record_info['earliest_date'] = run_sql("SELECT earliest_date FROM bibrec WHERE id=%s", (rec, ))[0][0].strftime("%Y-%m-%d")
+            ead = run_sql("SELECT earliest_date FROM bibrec WHERE id=%s", (rec, ))[0][0]
+            record_info['earliest_date'] = "{0}-{1:02d}-{2:02d}".format(ead.year, ead.month, ead.day)
         except:
             # Too bad
             pass


### PR DESCRIPTION
currently there are 123 records in `bibrec` table with `earliest_date < 1900`.  `strftime` fails with ValueError on these, e.g.

```
run_sql("SELECT earliest_date FROM bibrec WHERE id=%s", (44919, ))[0][0].strftime("%Y-%m-%d")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-37-2988b982ccf5> in <module>()
----> 1 run_sql("SELECT earliest_date FROM bibrec WHERE id=%s", (44919, ))[0][0].strftime("%Y-%m-%d")

ValueError: year=1867 is before 1900; the datetime strftime() methods require year >= 1900
```
therefore replace `strftime` with the desired `format` constructed from `datetime` properties year, month, day

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>