### PR TITLE
MiscUtil: fix reserved key in sentry logging

### DIFF
--- a/modules/miscutil/lib/errorlib.py
+++ b/modules/miscutil/lib/errorlib.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -410,7 +410,7 @@ def register_exception(stream='error',
                                         'env': req.environ})
                     client.extra_context(user_info)
                 filename = _get_filename_and_line(sys.exc_info())[0]
-                client.tags_context({'filename': filename, 'version': CFG_VERSION})
+                client.tags_context({'file_name': filename, 'version': CFG_VERSION})
                 client.captureException()
             finally:
                 client.context.clear()


### PR DESCRIPTION
Sentry currently shows errors for `tags_context`, e.g.

```
There was 1 error encountered while processing this event

    Discarded invalid value for parameter 'tags' Collapse

    {
      "name": "tags",
      "value": [
        "filename",
        "bfe_INSPIRE_abstract.py"
      ]
    }
```
so we change the key to `file_name`


    * fix tag key: filename is a reserved keyword

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>