### PR TITLE
BibFormat: handle dates < 1900 in google-meta

### DIFF
--- a/modules/bibformat/etc/format_templates/Default_HTML_meta.bft
+++ b/modules/bibformat/etc/format_templates/Default_HTML_meta.bft
@@ -14,7 +14,7 @@
 <BFE_META tag="773__i" tag_name="journal issue" name="citation_issue" />
 <BFE_META tag="773__t" name="citation_conference" />
 <BFE_META tag_name="abstract url" tag="8564_a" name="citation_abstract_url" />
-<BFE_META tag_name="date" tag="269__c,260__c" name="citation_publication_date" />
+<BFE_META tag_name="date" tag="269__c,260__c,773__y,502__d" name="citation_publication_date" />
 <BFE_CREATION_DATE format="%Y/%m/%d" prefix='<meta name="citation_online_date" content="' suffix='"/>' />
 <BFE_META tag="695__a" name="citation_keywords" />
 <BFE_META tag="037__a" name="citation_technical_report_number" />

--- a/modules/bibformat/lib/elements/bfe_meta.py
+++ b/modules/bibformat/lib/elements/bfe_meta.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2013 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2013, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -232,7 +232,9 @@ def parse_date_for_googlescholar(datetime_string):
                 pass
 
     if parsed_datetime:
-        return datetime(*(parsed_datetime[0:6])).strftime('%Y/%m/%d')
+        # avoid strftime because of its limitations for dates < 1900
+        dt = datetime(*(parsed_datetime[0:6]))
+        return "{0}/{1:02d}/{2:02d}".format(dt.year, dt.month, dt.day)
     else:
         # Look for a year inside the string:
         try:


### PR DESCRIPTION
    * avoid strftime and handle dates < 1900 in format element
    * use additional fields to look for dates in template

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>