### PR TITLE
RefExtract: fix IndexError in header detection

### DIFF
--- a/modules/docextract/lib/docextract_text.py
+++ b/modules/docextract/lib/docextract_text.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -283,9 +283,12 @@ def get_number_header_lines(docbody, page_break_posns):
                                               + num_header_lines + 1)])
             cur_break = cur_break + next_head
             while (cur_break < remaining_breaks) and keep_checking:
+                lineno = page_break_posns[cur_break] + num_header_lines + 1
+                if lineno >= len(docbody):
+                    keep_checking = 0
+                    break
                 grps_thisLineWords = \
-                    p_wordSearch.findall(docbody[(page_break_posns[cur_break] \
-                                                  + num_header_lines + 1)])
+                    p_wordSearch.findall(docbody[lineno])
                 if empty_line:
                     if len(grps_thisLineWords) != 0:
                         ## This line should be empty, but isn't


### PR DESCRIPTION
the header detection for a 3 page document with a trailing empty 4th page attempts to access lines beyond the document's end. this patch avoids the IndexError, it does not attempt to sanitize the convoluted header detection algorithm neither does it address other shortcomings in the case of several consecutive page-breaks early in the document.



Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>