### PR TITLE
BibEdit: use requests instead of urllib2

### DIFF
--- a/modules/bibedit/lib/bibedit_engine.py
+++ b/modules/bibedit/lib/bibedit_engine.py
@@ -25,9 +25,9 @@ from datetime import datetime
 import re
 import zlib
 import copy
+import requests
 import urllib
-import urllib2
-import cookielib
+
 
 from invenio import bibformat
 
@@ -1774,18 +1774,18 @@ def perform_doi_search(doi):
     @return: the url returned by this page"""
     response = {}
     url = "https://doi.org/"
-    val = {'hdl': doi}
-    url_data = urllib.urlencode(val)
-    cj = cookielib.CookieJar()
-    header = [('User-Agent', CFG_DOI_USER_AGENT)]
-    opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-    opener.addheaders = header
+    data = {'hdl': doi}
+    headers = {'user-agent': CFG_DOI_USER_AGENT}
     try:
-        resp = opener.open(url, url_data)
+        resp = requests.post(url, headers=headers, data=data,
+                             allow_redirects=False)
     except:
         return response
-    else:
-        response['doi_url'] = resp.geturl()
+
+    if resp.status_code in (301, 302):
+        redirect = resp.headers.get('Location', None)
+        if redirect:
+            response['doi_url'] = redirect
     return response
 
 


### PR DESCRIPTION

quick fix for SSL issues with legacy urllib2 connecting to https://doi.org

swap `urllib2` out for `requests`

there are better approaches, but no refactoring for legacy code.

DOI api with somewhat involved parsing
```
In [121]: data = json.loads(requests.get('https://doi.org/api/handles/10.1007/s00220-014-2176-9').text)

In [122]: [d[u'data'][u'value'] for d in data.get(u'values') if d.get(u'type') == u'URL']
Out[122]: [u'http://link.springer.com/10.1007/s00220-014-2176-9']
```

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>