### PR TITLE
MathJax: update to v2.7.5

### DIFF
--- a/modules/bibauthorid/etc/templates/head.html
+++ b/modules/bibauthorid/etc/templates/head.html
@@ -20,7 +20,7 @@ MathJax.Hub.Config({
         messageStyle: "none"
         });
 </script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript">
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript">
 </script>
 
 {% if stylesheets %}

--- a/modules/miscutil/lib/htmlutils.py
+++ b/modules/miscutil/lib/htmlutils.py
@@ -444,7 +444,7 @@ def get_mathjax_header(https=False):
            $MJV variable in the root Makefile.am
     """
     if CFG_MATHJAX_HOSTING.lower() == 'cdn':
-        mathjax_path = "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4"
+        mathjax_path = "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5"
     else:
         mathjax_path = "/MathJax"
 


### PR DESCRIPTION

simple update from MathJax 2.7.4 to 2.7.5 served via CDN

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>