### PR TITLE
Revert "WebAuthorProfile: temporary workaround for new link"

### DIFF
--- a/modules/webauthorprofile/lib/webauthorprofile_webinterface.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_webinterface.py
@@ -690,7 +690,7 @@ class WebAuthorPages(WebInterfaceDirectory):
                     'cname': webapi.get_canonical_id_from_person_id(person_id),
                     'link_to_record': ulevel == "admin",
                     'hepnames_link': "%s/%s/" % (CFG_BASE_URL, "record"),
-                    'new_record_link': 'https://%s/submissions/authors' % (CFG_LABS_HOSTNAME,),  # webapi.get_canonical_id_from_person_id(person_id)),
+                    'new_record_link': 'https://%s/submissions/authors?bai=%s' % (CFG_LABS_HOSTNAME, webapi.get_canonical_id_from_person_id(person_id)),
                     'update_link_prefix': "https://%s/submissions/authors/" % CFG_LABS_HOSTNAME,
                     'update_link_suffix': "",
                     'profile_link': "%s/%s" % (CFG_BASE_URL, "author/profile/")


### PR DESCRIPTION
This reverts commit b96d86f676a00923bdb16996dbd183b2405518d3.

to be merged/deployed after https://its.cern.ch/jira/browse/INSPIR-1817 is completed and deployed on labs