### PR TITLE
BibRank: set ap=0 for reportnumber search

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_indexer.py
+++ b/modules/bibrank/lib/bibrank_citation_indexer.py
@@ -941,7 +941,8 @@ def ref_analyzer(citation_informations, updated_recids, tags, config):
             # Search for "hep-th/5644654 or such" in existing records
             recids = get_recids_matching_query(p=refnumber,
                                                f=field,
-                                               config=config)
+                                               config=config,
+                                               ap=0)
             write_message("These match searching %s in %s: %s" %
                                    (refnumber, field, list(recids)), verbose=9)
 

--- a/modules/docextract/lib/refextract_linker.py
+++ b/modules/docextract/lib/refextract_linker.py
@@ -33,10 +33,10 @@ def config_cache(cache={}):
     return cache['config']
 
 
-def get_recids_matching_query(p, f, m='e'):
+def get_recids_matching_query(p, f, m='e', ap=1):
     """Return list of recIDs matching query for pattern and field."""
     config = config_cache()
-    recids = bibrank_search(p=p.encode('utf-8'), f=f, config=config, m=m)
+    recids = bibrank_search(p=p.encode('utf-8'), f=f, config=config, m=m, ap=ap)
     return list(recids)
 
 
@@ -67,7 +67,7 @@ def find_journal(citation_element):
 
 def find_reportnumber(citation_element):
     reportnumber = standardize_report_number(citation_element['report_num'])
-    recids = get_recids_matching_query(reportnumber, 'reportnumber')
+    recids = get_recids_matching_query(reportnumber, 'reportnumber', ap=0)
     return recids if len(recids) == 1 else []
 
 


### PR DESCRIPTION

    * avoid alternate pattern match for report number search
      because the resulting matches are too broad      

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>