### PR TITLE
WebInterface: redirect jobs to labs

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2,7 +2,7 @@
 
 ## This file is part of Invenio.
 ## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009,
-##               2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018 CERN.
+##               2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -134,6 +134,7 @@ from invenio.errorlib import register_exception
 from invenio.textutils import encode_for_xml, wash_for_utf8, strip_accents, translate_to_ascii
 from invenio.htmlutils import get_mathjax_header
 from invenio.htmlutils import nmtoken_from_string
+from invenio.urlutils import redirect_to_url
 from invenio import bibrecord
 
 import invenio.template
@@ -5645,6 +5646,13 @@ def prs_perform_search(kwargs=None, **dummy):
     out = prs_wash_arguments_colls(kwargs=kwargs, **kwargs)
     if not out:
         return out
+    if ('Jobs' in kwargs['colls_to_display'] or 'Jobs' in kwargs['colls_to_search']) and kwargs['req']:
+        if kwargs['recid']:
+            return redirect_to_url(kwargs['req'], 'https://labs.inspirehep.net/jobs/{0}'.format(kwargs['recid']),
+                                   apache.HTTP_MOVED_PERMANENTLY)
+        else:
+            return redirect_to_url(kwargs['req'], 'https://labs.inspirehep.net/jobs',
+                                   apache.HTTP_MOVED_PERMANENTLY)
     return prs_search(kwargs=kwargs, **kwargs)
 
 

--- a/modules/websearch/lib/websearch_webinterface.py
+++ b/modules/websearch/lib/websearch_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -435,6 +435,11 @@ class WebInterfaceSearchResultsPages(WebInterfaceDirectory):
         involved_collections = set()
         involved_collections.update(argd['c'])
         involved_collections.add(argd['cc'])
+        if involved_collections == set(('Jobs',)):
+            return redirect_to_url(req, 'https://labs.inspirehep.net/jobs',
+                                   apache.HTTP_MOVED_PERMANENTLY)
+        elif 'Jobs' in involved_collections:
+            involved_collections.discard('Jobs')
 
         if argd['id'] > 0:
             argd['recid'] = argd['id']
@@ -847,6 +852,9 @@ def display_collection(req, c, aas, verbose, ln, em=""):
 
     # deduce collection id:
     normalised_name = get_coll_normalised_name(c)
+    if normalised_name == 'Jobs':
+        redirect_to_url(req, 'https://labs.inspirehep.net/jobs',
+                        apache.HTTP_MOVED_PERMANENTLY)
     colID = get_colID(normalised_name)
     if type(colID) is not int:
         page_body = '<p>' + (_("Sorry, collection %s does not seem to exist.") % ('<strong>' + str(c) + '</strong>')) + '</p>'

--- a/modules/websubmit/lib/websubmit_webinterface.py
+++ b/modules/websubmit/lib/websubmit_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -874,6 +874,10 @@ class WebInterfaceSubmitPages(WebInterfaceDirectory):
             'step': (str, '0'),
             'mode': (str, 'U'),
             })
+
+        if args["doctype"].strip() == 'JOBSUBMIT':
+            return redirect_to_url(req, 'https://labs.inspirehep.net/submissions/jobs',
+                                   apache.HTTP_MOVED_PERMANENTLY)
 
         ## Strip whitespace from beginning and end of doctype and action:
         args["doctype"] = args["doctype"].strip()


### PR DESCRIPTION
    * WebSearch: redirect jobs collection to labs/jobs
    * WebSearch: redirect to labs for jobs /records/<id> requests
    * WebSubmit: redirect JOBSUBMIT to labs

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>