### PR TITLE
BibTask: correct limit on max(sequenceid)

### DIFF
--- a/modules/bibmerge/lib/bibmerge_engine.py
+++ b/modules/bibmerge/lib/bibmerge_engine.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -166,7 +166,7 @@ def perform_request_record(requestType, uid, data):
             record_add_field(record1, '981', ' ', ' ', '', [('a', str(recid2))])
 
             # To ensure updates happen in order, use a seq id
-            sequence_id = str(random.randrange(1, 4294967296))
+            sequence_id = str(random.randrange(1, 2147483648))
 
             # submit record2 to be deleted
             xml_record2 = record_xml_output(record2)

--- a/modules/bibsched/lib/bibtask.py
+++ b/modules/bibsched/lib/bibtask.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2018 CERN.
+## Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2018, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -341,7 +341,7 @@ def bibtask_allocate_sequenceid(curdir=None):
         except (IOError, OSError):
             return 0
     else:
-        return random.randrange(1, 4294967296)
+        return random.randrange(1, 2147483648)
 
 
 def task_log_path(task_id, log_type):

--- a/modules/miscutil/lib/sequtils_texkey.py
+++ b/modules/miscutil/lib/sequtils_texkey.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013, 2015, 2016 CERN.
+## Copyright (C) 2012, 2013, 2015, 2016, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -398,7 +398,7 @@ def task_run_core(name=NAME):
         task_sleep_now_if_required()
 
     # sequence ID to be used in all subsequent tasks
-    sequence_id = str(random.randrange(1, 4294967296))
+    sequence_id = str(random.randrange(1, 2147483648))
     if xml_to_process:
         process_chunk(xml_to_process, sequence_id)
 

--- a/modules/oaiharvest/lib/oai_harvest_daemon.py
+++ b/modules/oaiharvest/lib/oai_harvest_daemon.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -687,7 +687,7 @@ def upload_step(repository, active_files_list, uploaded_task_ids=None, *args, **
     final_exit_code = 0
     # Get a random sequence ID that will allow for the tasks to be
     # run in order, regardless if parallel task execution is activated
-    sequence_id = random.randrange(1, 4294967296)
+    sequence_id = random.randrange(1, 2147483648)
     for active_file in active_files_list:
         task_sleep_now_if_required()
         i += 1


### PR DESCRIPTION
    * The schTASK table defines sequenceid as int(8)
      it doesn't specify UNSIGNED, so max is 2**31 - 1
      and not 2**32 - 1.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>