### PR TITLE
WebSearch: avoid IndexError in recjson requests

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -3949,7 +3949,7 @@ def get_format_from_http_response(response):
         content_type = info.getheader('Content-Type')
     else:
         return ''
-        
+
     docformat = ''
 
     if content_disposition:

--- a/modules/miscutil/lib/containerutils.py
+++ b/modules/miscutil/lib/containerutils.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
+## Copyright (C) 2012, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -235,6 +235,9 @@ class SmartDict(object):
             else:
                 if chunk is None:
                     chunk = [None, ]
+                if key > 0:
+                    while len(chunk) <= key:
+                        chunk.append(None)
             chunk[key] = setitem(chunk[key])
         else: # dict
             if extend:

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -4994,7 +4994,10 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
                 continue
             if not can_see_hidden and key in CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS:
                 continue
-            record[key] = recjson.get(key)
+            try:
+                record[key] = recjson.get(key)
+            except IndexError:
+                pass
         # skipkeys is True to skip e.g. the bibdocs key, which is a non
         # primitive object.
         return json.dumps(dict(record), skipkeys=True)


### PR DESCRIPTION
    * a frequent error in recjson requests is ot=field[i]
      with i > 0. This corrects SmartDict to prefill lists to the desired position

    * also handle IndexErrors from i out of range

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>