### PR TITLE
BibRank: make citation graph width adaptable

### DIFF
--- a/modules/bibrank/lib/bibrank_citation_grapher.py
+++ b/modules/bibrank/lib/bibrank_citation_grapher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -113,7 +113,7 @@ def html_command(filename):
     """
     t = ''
     if CFG_BIBRANK_SHOW_CITATION_GRAPHS == 1:
-        t = '<img src="%s/%s/%s" align="middle" alt="Citation Graph" />' \
+        t = '<img src="%s/%s/%s" align="middle" alt="Citation Graph" style="max-width:95%%" />' \
                                            % (CFG_SITE_URL, REL_PATH, filename)
     elif CFG_BIBRANK_SHOW_CITATION_GRAPHS == 2:
         t = open(os.path.join(BASE_DIR, filename)).read()


### PR DESCRIPTION
    * make the citations graph in the citations tab scalable to avoid
       text overflow due to fixed table width (google mobile useability)

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>