### PR TITLE
WebInterface: redirect conferences to labs

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2,7 +2,7 @@
 
 ## This file is part of Invenio.
 ## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009,
-##               2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019 CERN.
+##               2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -5656,6 +5656,13 @@ def prs_perform_search(kwargs=None, **dummy):
                                    apache.HTTP_MOVED_PERMANENTLY)
         else:
             return redirect_to_url(kwargs['req'], 'https://labs.inspirehep.net/jobs',
+                                   apache.HTTP_MOVED_PERMANENTLY)
+    if ('Conferences' in kwargs['colls_to_display'] or 'Conferences' in kwargs['colls_to_search']) and kwargs['req']:
+        if kwargs['recid'] and kwargs['recid'] > 0:
+            return redirect_to_url(kwargs['req'], 'https://labs.inspirehep.net/conferences/{0}'.format(kwargs['recid']),
+                                   apache.HTTP_MOVED_PERMANENTLY)
+        else:
+            return redirect_to_url(kwargs['req'], 'https://labs.inspirehep.net/conferences',
                                    apache.HTTP_MOVED_PERMANENTLY)
     return prs_search(kwargs=kwargs, **kwargs)
 

--- a/modules/websearch/lib/websearch_webinterface.py
+++ b/modules/websearch/lib/websearch_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2019 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2019, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -442,6 +442,11 @@ class WebInterfaceSearchResultsPages(WebInterfaceDirectory):
                                    apache.HTTP_MOVED_PERMANENTLY)
         elif 'Jobs' in involved_collections:
             involved_collections.discard('Jobs')
+        if involved_collections == set(('Conferences',)):
+            return redirect_to_url(req, 'https://labs.inspirehep.net/conferences',
+                                   apache.HTTP_MOVED_PERMANENTLY)
+        elif 'Conferences' in involved_collections:
+            involved_collections.discard('Conferences')
 
         if argd['id'] > 0:
             argd['recid'] = argd['id']
@@ -861,6 +866,9 @@ def display_collection(req, c, aas, verbose, ln, em=""):
     normalised_name = get_coll_normalised_name(c)
     if normalised_name == 'Jobs':
         redirect_to_url(req, 'https://labs.inspirehep.net/jobs',
+                        apache.HTTP_MOVED_PERMANENTLY)
+    if normalised_name == 'Conferences':
+        redirect_to_url(req, 'https://labs.inspirehep.net/conferences',
                         apache.HTTP_MOVED_PERMANENTLY)
     colID = get_colID(normalised_name)
     if type(colID) is not int:

--- a/modules/websubmit/lib/websubmit_webinterface.py
+++ b/modules/websubmit/lib/websubmit_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2019 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2019, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -877,6 +877,9 @@ class WebInterfaceSubmitPages(WebInterfaceDirectory):
 
         if args["doctype"].strip() == 'JOBSUBMIT':
             return redirect_to_url(req, 'https://labs.inspirehep.net/submissions/jobs',
+                                   apache.HTTP_MOVED_PERMANENTLY)
+        if args["doctype"].strip() == 'CONFSUBMIT':
+            return redirect_to_url(req, 'https://labs.inspirehep.net/submissions/conferences',
                                    apache.HTTP_MOVED_PERMANENTLY)
 
         ## Strip whitespace from beginning and end of doctype and action:


### PR DESCRIPTION
    * WebSearch: redirect conferences collection to labs
    * WebSearch: redirect to labs for conferences /records/<id> requests
    * WebSubmit: redirect CONFSUBMIT to labs
Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>