### PR TITLE
MathJax: correct escaping of delimiter

### DIFF
--- a/modules/bibauthorid/etc/templates/head.html
+++ b/modules/bibauthorid/etc/templates/head.html
@@ -14,7 +14,7 @@
 
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$','$'], ['\\(', '\\)']],
+        tex2jax: {inlineMath: [['$','$'], ['\\\\(', '\\\\)']],
         processEscapes: true},
         showProcessingMessages: false,
         messageStyle: "none"

--- a/modules/miscutil/lib/htmlutils.py
+++ b/modules/miscutil/lib/htmlutils.py
@@ -455,7 +455,7 @@ def get_mathjax_header(https=False):
 
     return """<script type="text/x-mathjax-config">
 MathJax.Hub.Config({
-  tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']],
+  tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']],
             processEscapes: true},
   showProcessingMessages: false,
   messageStyle: "none"


### PR DESCRIPTION
Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>