### PR TITLE
GnuPlot: set default term

### DIFF
--- a/modules/bibrank/lib/bibrank_grapher.py
+++ b/modules/bibrank/lib/bibrank_grapher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2010, 2011, 2013 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2010, 2011, 2013, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -30,6 +30,7 @@ from invenio.config import (CFG_TMPSHAREDDIR, CFG_WEBDIR, CFG_SITE_URL,
 CFG_GNUPLOT_AVAILABLE = 1
 try:
     import Gnuplot
+    Gnuplot.GnuplotOpts.default_term = 'png'
 except ImportError, e:
     CFG_GNUPLOT_AVAILABLE = 0
 

--- a/modules/webauthorprofile/lib/webauthorprofile_publication_grapher.py
+++ b/modules/webauthorprofile/lib/webauthorprofile_publication_grapher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -26,6 +26,7 @@ from invenio.config import CFG_SITE_URL, CFG_SITE_SECURE_URL, CFG_WEBDIR
 cfg_gnuplot_available = 1
 try:
     import Gnuplot
+    Gnuplot.GnuplotOpts.default_term = 'png'
 except ImportError, e:
     cfg_gnuplot_available = 0
 

--- a/modules/webstat/lib/webstat_engine.py
+++ b/modules/webstat/lib/webstat_engine.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2007, 2008, 2010, 2011, 2013 CERN.
+## Copyright (C) 2007, 2008, 2010, 2011, 2013, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -2042,6 +2042,7 @@ def create_graph_trend_gnu_plot(trend, path, settings):
     """Creates the graph trend using the GNU plot library"""
     try:
         import Gnuplot
+        Gnuplot.GnuplotOpts.default_term = 'png'
     except ImportError:
         return
 


### PR DESCRIPTION
    * set the default_term to png to silence startup warning in
      error_log
        gnuplot: unable to open display ''
        gnuplot: X11 aborted.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>